### PR TITLE
Research NEP-413 signMessage implementation

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -29,6 +29,7 @@ export interface KeyPair {
   publicKey: PublicKey
   secretKey: string
   sign(message: Uint8Array): Signature
+  signNep413Message?(accountId: string, params: SignMessageParams): SignedMessage
 }
 
 export enum KeyType {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,6 +11,12 @@ export {
 export { formatGas, Gas, type GasInput, parseGas } from "./gas.js"
 export * from "./key.js"
 export {
+  generateNep413Nonce,
+  NEP413_TAG,
+  serializeNep413Message,
+  verifyNep413Signature,
+} from "./nep413.js"
+export {
   isValidAccountId,
   isValidPublicKey,
   validateAccountId,

--- a/src/utils/nep413.ts
+++ b/src/utils/nep413.ts
@@ -1,0 +1,168 @@
+/**
+ * NEP-413: Message signing utilities
+ *
+ * NEP-413 enables off-chain message signing for authentication and ownership verification
+ * without gas fees or blockchain transactions.
+ *
+ * @see https://github.com/near/NEPs/blob/master/neps/nep-0413.md
+ */
+
+import { b } from "@zorsh/zorsh"
+import { sha256 } from "@noble/hashes/sha2.js"
+import { ed25519 } from "@noble/curves/ed25519.js"
+import { base58, base64 } from "@scure/base"
+import type { SignMessageParams, SignedMessage } from "../core/types.js"
+import { parsePublicKey } from "./key.js"
+
+/**
+ * NEP-413 tag prefix: 2^31 + 413 = 2147484061
+ *
+ * This prefix ensures that signed messages cannot be confused with valid transactions.
+ * The tag makes the message too long to be a valid signer account ID.
+ */
+export const NEP413_TAG = 2147484061
+
+/**
+ * NEP-413 message payload schema
+ *
+ * Fields are serialized in this order:
+ * 1. message: string - The message to sign
+ * 2. nonce: [u8; 32] - 32-byte nonce for replay protection
+ * 3. recipient: string - Recipient identifier (e.g., "alice.near" or "myapp.com")
+ * 4. callbackUrl: Option<string> - Optional callback URL for web wallets
+ */
+export const Nep413PayloadSchema = b.struct({
+  message: b.string(),
+  nonce: b.array(b.u8(), 32),
+  recipient: b.string(),
+  callbackUrl: b.option(b.string()),
+})
+
+/**
+ * Serialize NEP-413 message parameters for signing
+ *
+ * Serialization steps:
+ * 1. Serialize the tag (2147484061) as u32
+ * 2. Serialize the payload (message, nonce, recipient, callbackUrl)
+ * 3. Concatenate: tag_bytes + payload_bytes
+ * 4. Hash with SHA256
+ *
+ * @param params - Message signing parameters
+ * @returns Serialized and hashed message ready for signing
+ *
+ * @example
+ * ```typescript
+ * const nonce = crypto.getRandomValues(new Uint8Array(32))
+ * const hash = serializeNep413Message({
+ *   message: "Login to MyApp",
+ *   recipient: "myapp.near",
+ *   nonce,
+ * })
+ * const signature = keyPair.sign(hash)
+ * ```
+ */
+export function serializeNep413Message(params: SignMessageParams): Uint8Array {
+  if (params.nonce.length !== 32) {
+    throw new Error("Nonce must be exactly 32 bytes")
+  }
+
+  // Serialize tag as u32
+  const tagBytes = b.u32().serialize(NEP413_TAG)
+
+  // Serialize payload
+  const payloadBytes = Nep413PayloadSchema.serialize({
+    message: params.message,
+    nonce: Array.from(params.nonce),
+    recipient: params.recipient,
+    callbackUrl: undefined, // Optional, not typically used in direct signing
+  })
+
+  // Concatenate tag + payload
+  const combined = new Uint8Array(tagBytes.length + payloadBytes.length)
+  combined.set(tagBytes, 0)
+  combined.set(payloadBytes, tagBytes.length)
+
+  // Hash the combined bytes
+  return sha256(combined)
+}
+
+/**
+ * Verify a NEP-413 signed message
+ *
+ * Verification steps:
+ * 1. Reconstruct the payload from parameters
+ * 2. Serialize and hash (tag + payload)
+ * 3. Verify the signature against the hash using the public key
+ *
+ * @param signedMessage - The signed message to verify
+ * @param params - Original message parameters (must match what was signed)
+ * @returns true if signature is valid, false otherwise
+ *
+ * @example
+ * ```typescript
+ * const isValid = verifyNep413Signature(signedMessage, {
+ *   message: "Login to MyApp",
+ *   recipient: "myapp.near",
+ *   nonce,
+ * })
+ * if (isValid) {
+ *   console.log("Signature verified!")
+ * }
+ * ```
+ */
+export function verifyNep413Signature(
+  signedMessage: SignedMessage,
+  params: SignMessageParams
+): boolean {
+  try {
+    // Parse the public key
+    const publicKey = parsePublicKey(signedMessage.publicKey)
+
+    // Only Ed25519 is currently supported
+    if (publicKey.keyType !== 0) {
+      throw new Error("Only Ed25519 keys are supported for NEP-413")
+    }
+
+    // Reconstruct the hashed payload
+    const hash = serializeNep413Message(params)
+
+    // Decode the signature
+    // Try base64 first (most common), fallback to base58
+    let signatureBytes: Uint8Array
+    try {
+      signatureBytes = base64.decode(signedMessage.signature)
+    } catch {
+      try {
+        // Remove ed25519: prefix if present
+        const sig = signedMessage.signature.replace("ed25519:", "")
+        signatureBytes = base58.decode(sig)
+      } catch {
+        return false
+      }
+    }
+
+    // Verify the signature
+    return ed25519.verify(signatureBytes, hash, publicKey.data)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Generate a random nonce for NEP-413 message signing
+ *
+ * @returns 32-byte random nonce
+ *
+ * @example
+ * ```typescript
+ * const nonce = generateNep413Nonce()
+ * const signedMessage = await near.signMessage({
+ *   message: "Login to MyApp",
+ *   recipient: "myapp.near",
+ *   nonce,
+ * })
+ * ```
+ */
+export function generateNep413Nonce(): Uint8Array {
+  return crypto.getRandomValues(new Uint8Array(32))
+}

--- a/tests/unit/nep413.test.ts
+++ b/tests/unit/nep413.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for NEP-413 message signing functionality
+ */
+
+import { describe, expect, test } from "bun:test"
+import {
+  Ed25519KeyPair,
+  generateNep413Nonce,
+  serializeNep413Message,
+  verifyNep413Signature,
+  NEP413_TAG,
+} from "../../src/utils/index.js"
+import type { SignMessageParams } from "../../src/core/types.js"
+
+describe("NEP-413 Message Signing", () => {
+  test("should generate a 32-byte nonce", () => {
+    const nonce = generateNep413Nonce()
+    expect(nonce).toBeInstanceOf(Uint8Array)
+    expect(nonce.length).toBe(32)
+  })
+
+  test("should serialize message with correct tag", () => {
+    const nonce = new Uint8Array(32).fill(1)
+    const params: SignMessageParams = {
+      message: "Hello, NEAR!",
+      recipient: "test.near",
+      nonce,
+    }
+
+    const serialized = serializeNep413Message(params)
+
+    // Should be a 32-byte hash (SHA256)
+    expect(serialized).toBeInstanceOf(Uint8Array)
+    expect(serialized.length).toBe(32)
+  })
+
+  test("should throw error for invalid nonce length", () => {
+    const invalidNonce = new Uint8Array(16) // Wrong size
+
+    expect(() => {
+      serializeNep413Message({
+        message: "test",
+        recipient: "test.near",
+        nonce: invalidNonce,
+      })
+    }).toThrow("Nonce must be exactly 32 bytes")
+  })
+
+  test("should sign and verify message correctly", () => {
+    const keyPair = Ed25519KeyPair.fromRandom()
+    const accountId = "test.near"
+    const nonce = generateNep413Nonce()
+
+    const params: SignMessageParams = {
+      message: "Login to MyApp",
+      recipient: "myapp.near",
+      nonce,
+    }
+
+    // Sign the message
+    const signedMessage = keyPair.signNep413Message(accountId, params)
+
+    // Verify the structure
+    expect(signedMessage.accountId).toBe(accountId)
+    expect(signedMessage.publicKey).toBe(keyPair.publicKey.toString())
+    expect(typeof signedMessage.signature).toBe("string")
+
+    // Verify the signature
+    const isValid = verifyNep413Signature(signedMessage, params)
+    expect(isValid).toBe(true)
+  })
+
+  test("should fail verification with wrong message", () => {
+    const keyPair = Ed25519KeyPair.fromRandom()
+    const accountId = "test.near"
+    const nonce = generateNep413Nonce()
+
+    const params: SignMessageParams = {
+      message: "Login to MyApp",
+      recipient: "myapp.near",
+      nonce,
+    }
+
+    const signedMessage = keyPair.signNep413Message(accountId, params)
+
+    // Try to verify with different message
+    const differentParams: SignMessageParams = {
+      message: "Different message",
+      recipient: "myapp.near",
+      nonce,
+    }
+
+    const isValid = verifyNep413Signature(signedMessage, differentParams)
+    expect(isValid).toBe(false)
+  })
+
+  test("should fail verification with wrong nonce", () => {
+    const keyPair = Ed25519KeyPair.fromRandom()
+    const accountId = "test.near"
+    const nonce = generateNep413Nonce()
+
+    const params: SignMessageParams = {
+      message: "Login to MyApp",
+      recipient: "myapp.near",
+      nonce,
+    }
+
+    const signedMessage = keyPair.signNep413Message(accountId, params)
+
+    // Try to verify with different nonce
+    const differentNonce = generateNep413Nonce()
+    const differentParams: SignMessageParams = {
+      message: "Login to MyApp",
+      recipient: "myapp.near",
+      nonce: differentNonce,
+    }
+
+    const isValid = verifyNep413Signature(signedMessage, differentParams)
+    expect(isValid).toBe(false)
+  })
+
+  test("should fail verification with wrong recipient", () => {
+    const keyPair = Ed25519KeyPair.fromRandom()
+    const accountId = "test.near"
+    const nonce = generateNep413Nonce()
+
+    const params: SignMessageParams = {
+      message: "Login to MyApp",
+      recipient: "myapp.near",
+      nonce,
+    }
+
+    const signedMessage = keyPair.signNep413Message(accountId, params)
+
+    // Try to verify with different recipient
+    const differentParams: SignMessageParams = {
+      message: "Login to MyApp",
+      recipient: "different.near",
+      nonce,
+    }
+
+    const isValid = verifyNep413Signature(signedMessage, differentParams)
+    expect(isValid).toBe(false)
+  })
+
+  test("should have correct NEP-413 tag value", () => {
+    // 2^31 + 413 = 2147484061
+    expect(NEP413_TAG).toBe(2147484061)
+  })
+
+  test("should produce deterministic signatures for same input", () => {
+    const keyPair = Ed25519KeyPair.fromRandom()
+    const accountId = "test.near"
+    const nonce = new Uint8Array(32).fill(42)
+
+    const params: SignMessageParams = {
+      message: "Login to MyApp",
+      recipient: "myapp.near",
+      nonce,
+    }
+
+    // Sign the same message twice
+    const signature1 = keyPair.signNep413Message(accountId, params)
+    const signature2 = keyPair.signNep413Message(accountId, params)
+
+    // Should produce identical signatures
+    expect(signature1.signature).toBe(signature2.signature)
+  })
+
+  test("should handle empty message", () => {
+    const keyPair = Ed25519KeyPair.fromRandom()
+    const accountId = "test.near"
+    const nonce = generateNep413Nonce()
+
+    const params: SignMessageParams = {
+      message: "",
+      recipient: "myapp.near",
+      nonce,
+    }
+
+    const signedMessage = keyPair.signNep413Message(accountId, params)
+    const isValid = verifyNep413Signature(signedMessage, params)
+    expect(isValid).toBe(true)
+  })
+
+  test("should handle long message", () => {
+    const keyPair = Ed25519KeyPair.fromRandom()
+    const accountId = "test.near"
+    const nonce = generateNep413Nonce()
+
+    const params: SignMessageParams = {
+      message: "A".repeat(10000), // Very long message
+      recipient: "myapp.near",
+      nonce,
+    }
+
+    const signedMessage = keyPair.signNep413Message(accountId, params)
+    const isValid = verifyNep413Signature(signedMessage, params)
+    expect(isValid).toBe(true)
+  })
+
+  test("should handle unicode characters in message", () => {
+    const keyPair = Ed25519KeyPair.fromRandom()
+    const accountId = "test.near"
+    const nonce = generateNep413Nonce()
+
+    const params: SignMessageParams = {
+      message: "こんにちは世界 🌍 Привет мир",
+      recipient: "myapp.near",
+      nonce,
+    }
+
+    const signedMessage = keyPair.signNep413Message(accountId, params)
+    const isValid = verifyNep413Signature(signedMessage, params)
+    expect(isValid).toBe(true)
+  })
+})


### PR DESCRIPTION
Implement NEP-413 off-chain message signing for authentication and ownership verification. This enables wallets and applications to sign messages without gas fees or blockchain transactions.

Features:
- Add signMessage() method to Near client
- Implement signNep413Message() on Ed25519KeyPair
- Add serialization with NEP-413 tag prefix (2^31 + 413)
- Add signature verification utility
- Generate random nonces for replay protection
- Full test coverage with 12 unit tests

NEP-413 enables use cases including:
- Login/authentication flows
- Account ownership verification
- Signing intents for meta-transactions
- Off-chain authorization

Implementation follows NEP-413 specification:
- Borsh serialization of message payload
- SHA256 hashing with tag prefix
- Ed25519 signature (SECP256K1 not yet supported)
- Base64-encoded signature output

Compatible with @near-wallet-selector and @hot-labs/near-connect wallet implementations.

Closes #6 