### PR TITLE
Design ergonomic global contracts API

### DIFF
--- a/src/core/transaction.ts
+++ b/src/core/transaction.ts
@@ -176,6 +176,73 @@ export class TransactionBuilder {
   }
 
   /**
+   * Publish a global contract that can be reused by multiple accounts
+   *
+   * @param code - The compiled contract code bytes
+   * @param publisherId - Optional account ID. If provided, creates a mutable contract (can be updated).
+   *                      If omitted, creates an immutable contract (identified by code hash).
+   *
+   * @example
+   * ```typescript
+   * // Publish immutable contract (identified by code hash)
+   * await near.transaction(accountId)
+   *   .publishContract(contractCode)
+   *   .send()
+   *
+   * // Publish mutable contract (identified by account, can be updated)
+   * await near.transaction(accountId)
+   *   .publishContract(contractCode, "my-publisher.near")
+   *   .send()
+   * ```
+   */
+  publishContract(code: Uint8Array, publisherId?: string): this {
+    this.actions.push(actions.publishContract(code, publisherId))
+
+    if (!this.receiverId) {
+      this.receiverId = this.signerId
+    }
+
+    return this
+  }
+
+  /**
+   * Deploy a contract to this account from previously published code in the global registry
+   *
+   * @param reference - Reference to the published contract, either:
+   *                    - { codeHash: Uint8Array | string } - Reference by code hash (Uint8Array or base58 string)
+   *                    - { accountId: string } - Reference by the account that published it
+   *
+   * @example
+   * ```typescript
+   * // Deploy from code hash (Uint8Array)
+   * await near.transaction(accountId)
+   *   .deployFromPublished({ codeHash: hashBytes })
+   *   .send()
+   *
+   * // Deploy from code hash (base58 string)
+   * await near.transaction(accountId)
+   *   .deployFromPublished({ codeHash: "5FzD8..." })
+   *   .send()
+   *
+   * // Deploy from account ID
+   * await near.transaction(accountId)
+   *   .deployFromPublished({ accountId: "contract-publisher.near" })
+   *   .send()
+   * ```
+   */
+  deployFromPublished(
+    reference: { codeHash: string | Uint8Array } | { accountId: string },
+  ): this {
+    this.actions.push(actions.deployFromPublished(reference))
+
+    if (!this.receiverId) {
+      this.receiverId = this.signerId
+    }
+
+    return this
+  }
+
+  /**
    * Add a stake action
    */
   stake(publicKey: string, amount: Amount): this {

--- a/tests/unit/global-contracts.test.ts
+++ b/tests/unit/global-contracts.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test"
+import { base58 } from "@scure/base"
+import { deployFromPublished, publishContract } from "../../src/core/actions.js"
+
+describe("Global Contracts API", () => {
+  test("publishContract creates immutable contract action", () => {
+    const code = new Uint8Array([0x00, 0x61, 0x73, 0x6d]) // WASM header
+    const action = publishContract(code)
+
+    expect(action).toHaveProperty("deployGlobalContract")
+    expect(action.deployGlobalContract.code).toEqual(code)
+    expect(action.deployGlobalContract.deployMode).toEqual({ CodeHash: {} })
+  })
+
+  test("publishContract creates mutable contract action", () => {
+    const code = new Uint8Array([0x00, 0x61, 0x73, 0x6d])
+    const accountId = "my-publisher.near"
+    const action = publishContract(code, accountId)
+
+    expect(action).toHaveProperty("deployGlobalContract")
+    expect(action.deployGlobalContract.code).toEqual(code)
+    expect(action.deployGlobalContract.deployMode).toEqual({ AccountId: {} })
+  })
+
+  test("deployFromPublished with accountId", () => {
+    const accountId = "contract-publisher.near"
+    const action = deployFromPublished({ accountId })
+
+    expect(action).toHaveProperty("useGlobalContract")
+    expect(action.useGlobalContract.contractIdentifier).toEqual({
+      AccountId: accountId,
+    })
+  })
+
+  test("deployFromPublished with codeHash as Uint8Array", () => {
+    const codeHash = new Uint8Array(32).fill(0xab)
+    const action = deployFromPublished({ codeHash })
+
+    expect(action).toHaveProperty("useGlobalContract")
+    expect(action.useGlobalContract.contractIdentifier).toHaveProperty(
+      "CodeHash",
+    )
+    expect(action.useGlobalContract.contractIdentifier.CodeHash).toEqual(
+      Array.from(codeHash),
+    )
+  })
+
+  test("deployFromPublished with codeHash as base58 string", () => {
+    const hashBytes = new Uint8Array(32).fill(0xab)
+    const codeHashBase58 = base58.encode(hashBytes)
+    const action = deployFromPublished({ codeHash: codeHashBase58 })
+
+    expect(action).toHaveProperty("useGlobalContract")
+    expect(action.useGlobalContract.contractIdentifier).toHaveProperty(
+      "CodeHash",
+    )
+    expect(action.useGlobalContract.contractIdentifier.CodeHash).toEqual(
+      Array.from(hashBytes),
+    )
+  })
+
+  test("deployFromPublished throws on invalid hash length", () => {
+    const invalidHash = new Uint8Array(16) // Wrong length
+
+    expect(() => {
+      deployFromPublished({ codeHash: invalidHash })
+    }).toThrow("Code hash must be 32 bytes")
+  })
+
+  test("deployFromPublished throws on invalid base58 hash length", () => {
+    const invalidHashBytes = new Uint8Array(16)
+    const invalidHashBase58 = base58.encode(invalidHashBytes)
+
+    expect(() => {
+      deployFromPublished({ codeHash: invalidHashBase58 })
+    }).toThrow("Code hash must be 32 bytes")
+  })
+})


### PR DESCRIPTION
Replace the verbose global contract API with simplified methods matching near-api-js and near-sdk-rs conventions.

New API:
- publishContract(code, accountId?) - publish immutable or mutable contracts
- deployFromPublished(reference) - deploy from published code by hash or account

Changes:
- Remove GlobalContractDeployMode and GlobalContractIdentifier classes
- Replace deployGlobalContract() with publishContract()
- Replace useGlobalContract() with deployFromPublished()
- Add TransactionBuilder methods for both operations
- Support base58 encoded code hashes in addition to Uint8Array

The new API uses:
- Optional parameters instead of separate methods
- Discriminated unions for type-safe references
- Clearer method names that describe intent

Breaking: Removes old global contract classes and methods. This is acceptable as the library is under active development.

Closes #9 