### PR TITLE
Brainstorm transaction signing and hash handling

### DIFF
--- a/tests/integration/transaction-signing.test.ts
+++ b/tests/integration/transaction-signing.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Integration tests for transaction signing
+ *
+ * These tests require a running NEAR sandbox or testnet access.
+ * They can be run manually or in CI with appropriate setup.
+ *
+ * To run against sandbox:
+ * 1. Start near-sandbox
+ * 2. Run: bun test tests/integration/transaction-signing.test.ts
+ */
+
+import { describe, expect, test, beforeAll } from "bun:test"
+import { Near } from "../../src/index.js"
+import { Amount } from "../../src/utils/amount.js"
+
+// These tests are skipped by default since they require network access
+// Set INTEGRATION_TESTS=true to run them
+const describeIntegration = process.env.INTEGRATION_TESTS === "true" ? describe : describe.skip
+
+describeIntegration("Transaction Signing - Integration Tests", () => {
+  let near: Near
+  let testAccountId: string
+  let testPrivateKey: string
+
+  beforeAll(() => {
+    // Configuration for sandbox or testnet
+    const rpcUrl = process.env.NEAR_RPC_URL || "http://localhost:3030"
+    const networkId = process.env.NEAR_NETWORK_ID || "sandbox"
+
+    // Test account credentials (should be set in env or use sandbox defaults)
+    testAccountId = process.env.NEAR_TEST_ACCOUNT || "test.near"
+    testPrivateKey =
+      process.env.NEAR_TEST_PRIVATE_KEY ||
+      "ed25519:3D4YudUahN1nawWogh8pAKSj92sUNMdbZGjn7kERKzYoTy8oryFtvLGoBnu1J6N4qVWY9jXwfLiNWnaTzKkHNfqG"
+
+    near = new Near({
+      networkId: networkId as any,
+      rpcUrl,
+      keyStore: "memory",
+    })
+  })
+
+  test("should sign a transaction and get hash before sending", async () => {
+    await near.addKey(testAccountId, testPrivateKey)
+
+    const tx = await near
+      .transaction(testAccountId)
+      .transfer(testAccountId, Amount.NEAR(0))
+      .sign()
+
+    const hash = tx.getHash()
+    expect(hash).toBeTruthy()
+    expect(typeof hash).toBe("string")
+    expect(hash!.length).toBeGreaterThan(40) // Base58 hash should be long
+  })
+
+  test("should send pre-signed transaction", async () => {
+    await near.addKey(testAccountId, testPrivateKey)
+
+    // Sign first
+    const tx = await near
+      .transaction(testAccountId)
+      .transfer(testAccountId, Amount.NEAR(0))
+      .sign()
+
+    const hashBeforeSend = tx.getHash()
+
+    // Send later
+    const result = await tx.send()
+
+    // Hash should match
+    expect(result.transaction.hash).toBe(hashBeforeSend)
+    expect(result.final_execution_status).toBe("EXECUTED_OPTIMISTIC")
+  })
+
+  test("should serialize and deserialize transaction", async () => {
+    await near.addKey(testAccountId, testPrivateKey)
+
+    const tx = await near
+      .transaction(testAccountId)
+      .transfer(testAccountId, Amount.NEAR(0))
+      .sign()
+
+    const bytes = tx.serialize()
+    expect(bytes).toBeInstanceOf(Uint8Array)
+    expect(bytes.length).toBeGreaterThan(0)
+
+    // TODO: Add deserialization and re-send test when we add deserialize support
+  })
+
+  test("should return transaction hash with NONE finality", async () => {
+    await near.addKey(testAccountId, testPrivateKey)
+
+    const result = await near
+      .transaction(testAccountId)
+      .transfer(testAccountId, Amount.NEAR(0))
+      .send({ waitUntil: "NONE" })
+
+    // Transaction hash should be injected
+    expect(result.transaction).toBeDefined()
+    expect(result.transaction!.hash).toBeTruthy()
+    expect(result.transaction!.signer_id).toBe(testAccountId)
+    expect(result.transaction!.receiver_id).toBe(testAccountId)
+    expect(typeof result.transaction!.nonce).toBe("number")
+
+    expect(result.final_execution_status).toBe("NONE")
+  })
+
+  test("should return transaction hash with INCLUDED finality", async () => {
+    await near.addKey(testAccountId, testPrivateKey)
+
+    const result = await near
+      .transaction(testAccountId)
+      .transfer(testAccountId, Amount.NEAR(0))
+      .send({ waitUntil: "INCLUDED" })
+
+    expect(result.transaction).toBeDefined()
+    expect(result.transaction!.hash).toBeTruthy()
+    expect(result.final_execution_status).toBe("INCLUDED")
+  })
+
+  test("should return full transaction with EXECUTED_OPTIMISTIC", async () => {
+    await near.addKey(testAccountId, testPrivateKey)
+
+    const result = await near
+      .transaction(testAccountId)
+      .transfer(testAccountId, Amount.NEAR(0))
+      .send({ waitUntil: "EXECUTED_OPTIMISTIC" })
+
+    expect(result.transaction).toBeDefined()
+    expect(result.transaction.hash).toBeTruthy()
+    expect(result.transaction.signer_id).toBe(testAccountId)
+    expect(result.transaction.actions).toBeDefined()
+    expect(result.transaction.signature).toBeDefined()
+    expect(result.final_execution_status).toBe("EXECUTED_OPTIMISTIC")
+  })
+
+  test("should handle multiple actions in one transaction", async () => {
+    await near.addKey(testAccountId, testPrivateKey)
+
+    const tx = await near
+      .transaction(testAccountId)
+      .transfer(testAccountId, Amount.NEAR(0))
+      .functionCall(testAccountId, "noop", {})
+      .sign()
+
+    const hash = tx.getHash()
+    expect(hash).toBeTruthy()
+
+    const result = await tx.send()
+    expect(result.transaction.hash).toBe(hash)
+  })
+
+  test("should invalidate cache when adding actions after signing", async () => {
+    await near.addKey(testAccountId, testPrivateKey)
+
+    const tx = near.transaction(testAccountId).transfer(testAccountId, Amount.NEAR(0))
+
+    await tx.sign()
+    const firstHash = tx.getHash()
+
+    // Add another action
+    tx.transfer(testAccountId, Amount.NEAR(0))
+
+    // Cache should be invalidated
+    expect(tx.getHash()).toBeNull()
+
+    // Re-sign
+    await tx.sign()
+    const newHash = tx.getHash()
+
+    expect(newHash).not.toBe(firstHash)
+  })
+
+  test("should work with signWith() override", async () => {
+    await near.addKey(testAccountId, testPrivateKey)
+
+    const result = await near
+      .transaction(testAccountId)
+      .signWith(testPrivateKey)
+      .transfer(testAccountId, Amount.NEAR(0))
+      .send()
+
+    expect(result.transaction.hash).toBeTruthy()
+    expect(result.final_execution_status).toBe("EXECUTED_OPTIMISTIC")
+  })
+
+  test("should handle nonce retry on send", async () => {
+    await near.addKey(testAccountId, testPrivateKey)
+
+    // This test verifies that nonce retries work
+    // In normal operation, nonce errors are rare, but the retry logic should handle them
+
+    const result = await near
+      .transaction(testAccountId)
+      .transfer(testAccountId, Amount.NEAR(0))
+      .send()
+
+    expect(result.transaction.hash).toBeTruthy()
+  })
+
+  test("same hash when signing multiple times without changes", async () => {
+    await near.addKey(testAccountId, testPrivateKey)
+
+    const tx = near.transaction(testAccountId).transfer(testAccountId, Amount.NEAR(0))
+
+    await tx.sign()
+    const hash1 = tx.getHash()
+
+    // Sign again without changes - should use cache
+    await tx.sign()
+    const hash2 = tx.getHash()
+
+    expect(hash1).toBe(hash2)
+  })
+})
+
+describeIntegration("Transaction Signing - Complex Scenarios", () => {
+  let near: Near
+  let testAccountId: string
+  let testPrivateKey: string
+
+  beforeAll(() => {
+    const rpcUrl = process.env.NEAR_RPC_URL || "http://localhost:3030"
+    const networkId = process.env.NEAR_NETWORK_ID || "sandbox"
+
+    testAccountId = process.env.NEAR_TEST_ACCOUNT || "test.near"
+    testPrivateKey =
+      process.env.NEAR_TEST_PRIVATE_KEY ||
+      "ed25519:3D4YudUahN1nawWogh8pAKSj92sUNMdbZGjn7kERKzYoTy8oryFtvLGoBnu1J6N4qVWY9jXwfLiNWnaTzKkHNfqG"
+
+    near = new Near({
+      networkId: networkId as any,
+      rpcUrl,
+      keyStore: "memory",
+    })
+  })
+
+  test("should track transaction with NONE then poll with hash", async () => {
+    await near.addKey(testAccountId, testPrivateKey)
+
+    // Send with NONE to get quick response
+    const result = await near
+      .transaction(testAccountId)
+      .transfer(testAccountId, Amount.NEAR(0))
+      .send({ waitUntil: "NONE" })
+
+    const txHash = result.transaction!.hash
+
+    // Wait a bit for transaction to process
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    // Poll for status using the hash
+    const status = await near.getTransactionStatus(txHash, testAccountId)
+
+    expect(status.final_execution_status).toBeDefined()
+    // Status should eventually be executed
+    expect(["EXECUTED_OPTIMISTIC", "EXECUTED", "FINAL"]).toContain(
+      status.final_execution_status,
+    )
+  })
+
+  test("should handle batch operations with individual signing", async () => {
+    await near.addKey(testAccountId, testPrivateKey)
+
+    // Create and sign multiple transactions
+    const tx1 = await near
+      .transaction(testAccountId)
+      .transfer(testAccountId, Amount.NEAR(0))
+      .sign()
+
+    const tx2 = await near
+      .transaction(testAccountId)
+      .transfer(testAccountId, Amount.NEAR(0))
+      .sign()
+
+    const hash1 = tx1.getHash()
+    const hash2 = tx2.getHash()
+
+    expect(hash1).not.toBe(hash2) // Different transactions should have different hashes
+
+    // Send both
+    const result1 = await tx1.send()
+    const result2 = await tx2.send()
+
+    expect(result1.transaction.hash).toBe(hash1)
+    expect(result2.transaction.hash).toBe(hash2)
+  })
+
+  test("should work with custom signer function", async () => {
+    await near.addKey(testAccountId, testPrivateKey)
+
+    // Create custom signer that delegates to key pair
+    const keyPair = await near.keys.get(testAccountId)
+    const customSigner = async (message: Uint8Array) => {
+      return keyPair!.sign(message)
+    }
+
+    const result = await near
+      .transaction(testAccountId)
+      .signWith(customSigner)
+      .transfer(testAccountId, Amount.NEAR(0))
+      .send()
+
+    expect(result.transaction.hash).toBeTruthy()
+  })
+})

--- a/tests/unit/transaction-signing.test.ts
+++ b/tests/unit/transaction-signing.test.ts
@@ -1,0 +1,482 @@
+/**
+ * Tests for transaction signing functionality
+ */
+
+import { describe, expect, test, beforeEach } from "bun:test"
+import { RpcClient } from "../../src/core/rpc/rpc.js"
+import { TransactionBuilder } from "../../src/core/transaction.js"
+import { InMemoryKeyStore } from "../../src/keys/index.js"
+import { Amount } from "../../src/utils/amount.js"
+import { parseKey } from "../../src/utils/key.js"
+
+// Valid test keys
+const TEST_PRIVATE_KEY =
+  "ed25519:3D4YudUahN1nawWogh8pAKSj92sUNMdbZGjn7kERKzYoTy8oryFtvLGoBnu1J6N4qVWY9jXwfLiNWnaTzKkHNfqG"
+const TEST_PUBLIC_KEY = "ed25519:DcA2MzgpJbrUATQLLceocVckhhAqrkingax4oJ9kZ847"
+
+// Helper to create a transaction builder for testing with mocked RPC
+function createBuilderWithMocks(): {
+  builder: TransactionBuilder
+  rpc: RpcClient
+  keyStore: InMemoryKeyStore
+} {
+  const rpc = new RpcClient("https://rpc.testnet.fastnear.com")
+  const keyStore = new InMemoryKeyStore()
+
+  // Mock RPC methods to avoid network calls
+  ;(rpc as any).getAccessKey = async () => ({
+    nonce: 100,
+    permission: "FullAccess",
+    block_height: 1000,
+    block_hash: "11111111111111111111111111111111",
+  })
+  ;(rpc as any).getStatus = async () => ({
+    sync_info: {
+      latest_block_hash: "GwVStJW8yLesiDA1Fhd7tkMx48ViJQBoTMBBLXa2YUhP",
+    },
+  })
+
+  const builder = new TransactionBuilder("alice.near", rpc, keyStore)
+
+  return { builder, rpc, keyStore }
+}
+
+describe("TransactionBuilder - .sign() method", () => {
+  test("should sign a transaction and cache the result", async () => {
+    const { builder, keyStore } = createBuilderWithMocks()
+
+    // Add a key to the keyStore
+    const keyPair = parseKey(TEST_PRIVATE_KEY)
+    await keyStore.add("alice.near", keyPair)
+
+    // Build and sign
+    const signedBuilder = await builder.transfer("bob.near", Amount.NEAR(1)).sign()
+
+    // Should return the same builder instance
+    expect(signedBuilder).toBe(builder)
+
+    // Should have a hash available
+    const hash = signedBuilder.getHash()
+    expect(hash).toBeTruthy()
+    expect(typeof hash).toBe("string")
+    expect(hash!.length).toBeGreaterThan(0)
+  })
+
+  test("should return cached result on second .sign() call", async () => {
+    const { builder, keyStore } = createBuilderWithMocks()
+
+    const keyPair = parseKey(TEST_PRIVATE_KEY)
+    await keyStore.add("alice.near", keyPair)
+
+    await builder.transfer("bob.near", Amount.NEAR(1)).sign()
+    const firstHash = builder.getHash()
+
+    // Sign again - should use cache
+    await builder.sign()
+    const secondHash = builder.getHash()
+
+    expect(firstHash).toBe(secondHash)
+  })
+
+  test("should invalidate cache when adding actions", async () => {
+    const { builder, keyStore } = createBuilderWithMocks()
+
+    const keyPair = parseKey(TEST_PRIVATE_KEY)
+    await keyStore.add("alice.near", keyPair)
+
+    // Sign first transaction
+    await builder.transfer("bob.near", Amount.NEAR(1)).sign()
+    const firstHash = builder.getHash()
+
+    // Add another action - should invalidate cache
+    builder.transfer("carol.near", Amount.NEAR(2))
+    const hashAfterAction = builder.getHash()
+
+    // Hash should be null since cache was invalidated
+    expect(hashAfterAction).toBeNull()
+
+    // Re-sign with new actions
+    await builder.sign()
+    const newHash = builder.getHash()
+
+    // New hash should be different
+    expect(newHash).not.toBe(firstHash)
+  })
+
+  test("should invalidate cache for all action methods", async () => {
+    const { builder, keyStore } = createBuilderWithMocks()
+
+    const keyPair = parseKey(TEST_PRIVATE_KEY)
+    await keyStore.add("alice.near", keyPair)
+
+    // Sign
+    await builder.transfer("bob.near", Amount.NEAR(1)).sign()
+    expect(builder.getHash()).not.toBeNull()
+
+    // Each action method should invalidate cache
+    builder.functionCall("contract.near", "method", {})
+    expect(builder.getHash()).toBeNull()
+
+    await builder.sign()
+    expect(builder.getHash()).not.toBeNull()
+
+    builder.createAccount("new.near")
+    expect(builder.getHash()).toBeNull()
+
+    await builder.sign()
+    expect(builder.getHash()).not.toBeNull()
+
+    builder.deleteAccount("beneficiary.near")
+    expect(builder.getHash()).toBeNull()
+
+    await builder.sign()
+    expect(builder.getHash()).not.toBeNull()
+
+    builder.deployContract("contract.near", new Uint8Array())
+    expect(builder.getHash()).toBeNull()
+
+    await builder.sign()
+    expect(builder.getHash()).not.toBeNull()
+
+    builder.stake(TEST_PUBLIC_KEY, Amount.NEAR(100))
+    expect(builder.getHash()).toBeNull()
+
+    await builder.sign()
+    expect(builder.getHash()).not.toBeNull()
+
+    builder.addKey(TEST_PUBLIC_KEY, { type: "fullAccess" })
+    expect(builder.getHash()).toBeNull()
+
+    await builder.sign()
+    expect(builder.getHash()).not.toBeNull()
+
+    builder.deleteKey("alice.near", TEST_PUBLIC_KEY)
+    expect(builder.getHash()).toBeNull()
+  })
+
+  test("should invalidate cache when changing signer with signWith()", async () => {
+    const { builder, keyStore } = createBuilderWithMocks()
+
+    const keyPair = parseKey(TEST_PRIVATE_KEY)
+    await keyStore.add("alice.near", keyPair)
+
+    // Sign
+    await builder.transfer("bob.near", Amount.NEAR(1)).sign()
+    const firstHash = builder.getHash()
+
+    // Change signer - should invalidate cache
+    builder.signWith(TEST_PRIVATE_KEY)
+    expect(builder.getHash()).toBeNull()
+
+    // Re-sign
+    await builder.sign()
+    const newHash = builder.getHash()
+
+    // Hash might be same or different depending on if key is same,
+    // but important thing is cache was invalidated
+    expect(newHash).toBeTruthy()
+  })
+
+  test("getHash() should return null before signing", () => {
+    const { builder } = createBuilderWithMocks()
+
+    builder.transfer("bob.near", Amount.NEAR(1))
+
+    expect(builder.getHash()).toBeNull()
+  })
+
+  test("getHash() should return base58 string after signing", async () => {
+    const { builder, keyStore } = createBuilderWithMocks()
+
+    const keyPair = parseKey(TEST_PRIVATE_KEY)
+    await keyStore.add("alice.near", keyPair)
+
+    await builder.transfer("bob.near", Amount.NEAR(1)).sign()
+
+    const hash = builder.getHash()
+    expect(hash).toBeTruthy()
+    expect(typeof hash).toBe("string")
+    expect(hash!.length).toBeGreaterThan(40) // Base58 hashes are typically 44 chars
+  })
+
+  test("should throw error when signing without receiver", async () => {
+    const { builder, keyStore } = createBuilderWithMocks()
+
+    const keyPair = parseKey(TEST_PRIVATE_KEY)
+    await keyStore.add("alice.near", keyPair)
+
+    // Don't add any actions (no receiverId set)
+    await expect(builder.sign()).rejects.toThrow("No receiver ID set")
+  })
+
+  test("should throw error when signing without key", async () => {
+    const { builder } = createBuilderWithMocks()
+
+    // Don't add key to keyStore
+    builder.transfer("bob.near", Amount.NEAR(1))
+
+    await expect(builder.sign()).rejects.toThrow("No key found")
+  })
+})
+
+describe("TransactionBuilder - .serialize() method", () => {
+  test("should serialize signed transaction to bytes", async () => {
+    const { builder, keyStore } = createBuilderWithMocks()
+
+    const keyPair = parseKey(TEST_PRIVATE_KEY)
+    await keyStore.add("alice.near", keyPair)
+
+    await builder.transfer("bob.near", Amount.NEAR(1)).sign()
+
+    const bytes = builder.serialize()
+
+    expect(bytes).toBeInstanceOf(Uint8Array)
+    expect(bytes.length).toBeGreaterThan(0)
+  })
+
+  test("should throw error when serializing before signing", () => {
+    const { builder } = createBuilderWithMocks()
+
+    builder.transfer("bob.near", Amount.NEAR(1))
+
+    expect(() => builder.serialize()).toThrow(
+      "Transaction must be signed before serializing",
+    )
+  })
+
+  test("should throw error when serializing after cache invalidation", async () => {
+    const { builder, keyStore } = createBuilderWithMocks()
+
+    const keyPair = parseKey(TEST_PRIVATE_KEY)
+    await keyStore.add("alice.near", keyPair)
+
+    await builder.transfer("bob.near", Amount.NEAR(1)).sign()
+
+    // Invalidate cache
+    builder.transfer("carol.near", Amount.NEAR(2))
+
+    // Should throw since cache was invalidated
+    expect(() => builder.serialize()).toThrow(
+      "Transaction must be signed before serializing",
+    )
+  })
+
+  test("serialized bytes should be deterministic", async () => {
+    const { builder, keyStore } = createBuilderWithMocks()
+
+    const keyPair = parseKey(TEST_PRIVATE_KEY)
+    await keyStore.add("alice.near", keyPair)
+
+    await builder.transfer("bob.near", Amount.NEAR(1)).sign()
+
+    const bytes1 = builder.serialize()
+    const bytes2 = builder.serialize()
+
+    // Multiple calls should return same bytes
+    expect(bytes1).toEqual(bytes2)
+  })
+})
+
+describe("TransactionBuilder - sign and send workflow", () => {
+  test("should allow signing then sending later", async () => {
+    const { builder, keyStore, rpc } = createBuilderWithMocks()
+
+    const keyPair = parseKey(TEST_PRIVATE_KEY)
+    await keyStore.add("alice.near", keyPair)
+
+    // Mock sendTransaction
+    let capturedHash: string | undefined
+    ;(rpc as any).sendTransaction = async (
+      _bytes: Uint8Array,
+      _waitUntil: string,
+    ) => {
+      return {
+        final_execution_status: "EXECUTED_OPTIMISTIC",
+        status: { SuccessValue: "" },
+        transaction: {
+          hash: capturedHash,
+          signer_id: "alice.near",
+          receiver_id: "bob.near",
+          nonce: 101,
+          public_key: TEST_PUBLIC_KEY,
+          actions: [],
+          signature: "sig...",
+        },
+        transaction_outcome: {
+          id: "tx123",
+          outcome: {
+            logs: [],
+            receipt_ids: [],
+            gas_burnt: 1000000,
+            tokens_burnt: "0",
+            executor_id: "alice.near",
+            status: { SuccessValue: "" },
+          },
+        },
+        receipts_outcome: [],
+      }
+    }
+
+    // Sign first
+    await builder.transfer("bob.near", Amount.NEAR(1)).sign()
+    capturedHash = builder.getHash()!
+
+    // Send later
+    const result = await builder.send()
+
+    expect(result.transaction.hash).toBe(capturedHash)
+  })
+
+  test("should use cached signed tx when sending", async () => {
+    const { builder, keyStore, rpc } = createBuilderWithMocks()
+
+    const keyPair = parseKey(TEST_PRIVATE_KEY)
+    await keyStore.add("alice.near", keyPair)
+
+    let signCallCount = 0
+    const originalSign = builder.sign.bind(builder)
+    builder.sign = async function () {
+      signCallCount++
+      return originalSign()
+    }
+
+    // Mock sendTransaction
+    ;(rpc as any).sendTransaction = async () => ({
+      final_execution_status: "EXECUTED_OPTIMISTIC",
+      status: { SuccessValue: "" },
+      transaction: {
+        hash: "hash123",
+        signer_id: "alice.near",
+        receiver_id: "bob.near",
+        nonce: 101,
+        public_key: TEST_PUBLIC_KEY,
+        actions: [],
+        signature: "sig...",
+      },
+      transaction_outcome: {
+        id: "tx123",
+        outcome: {
+          logs: [],
+          receipt_ids: [],
+          gas_burnt: 1000000,
+          tokens_burnt: "0",
+          executor_id: "alice.near",
+          status: { SuccessValue: "" },
+        },
+      },
+      receipts_outcome: [],
+    })
+
+    // Sign then send
+    await builder.transfer("bob.near", Amount.NEAR(1)).sign()
+    expect(signCallCount).toBe(1)
+
+    await builder.send()
+    // Should not sign again since we used cached tx
+    expect(signCallCount).toBe(1)
+  })
+})
+
+describe("TransactionBuilder - hash in NONE finality responses", () => {
+  test("should inject transaction hash for NONE finality", async () => {
+    const { builder, keyStore, rpc } = createBuilderWithMocks()
+
+    const keyPair = parseKey(TEST_PRIVATE_KEY)
+    await keyStore.add("alice.near", keyPair)
+
+    // Mock sendTransaction to return NONE response
+    ;(rpc as any).sendTransaction = async () => ({
+      final_execution_status: "NONE",
+    })
+
+    const result = await builder
+      .transfer("bob.near", Amount.NEAR(1))
+      .send({ waitUntil: "NONE" })
+
+    // Should have injected transaction fields
+    expect(result.transaction).toBeDefined()
+    expect(result.transaction!.hash).toBeTruthy()
+    expect(result.transaction!.signer_id).toBe("alice.near")
+    expect(result.transaction!.receiver_id).toBe("bob.near")
+    expect(result.transaction!.nonce).toBe(101) // nonce + 1
+  })
+
+  test("should inject transaction hash for INCLUDED finality", async () => {
+    const { builder, keyStore, rpc } = createBuilderWithMocks()
+
+    const keyPair = parseKey(TEST_PRIVATE_KEY)
+    await keyStore.add("alice.near", keyPair)
+
+    ;(rpc as any).sendTransaction = async () => ({
+      final_execution_status: "INCLUDED",
+    })
+
+    const result = await builder
+      .transfer("bob.near", Amount.NEAR(1))
+      .send({ waitUntil: "INCLUDED" })
+
+    expect(result.transaction).toBeDefined()
+    expect(result.transaction!.hash).toBeTruthy()
+    expect(result.transaction!.signer_id).toBe("alice.near")
+    expect(result.transaction!.receiver_id).toBe("bob.near")
+  })
+
+  test("should inject transaction hash for INCLUDED_FINAL finality", async () => {
+    const { builder, keyStore, rpc } = createBuilderWithMocks()
+
+    const keyPair = parseKey(TEST_PRIVATE_KEY)
+    await keyStore.add("alice.near", keyPair)
+
+    ;(rpc as any).sendTransaction = async () => ({
+      final_execution_status: "INCLUDED_FINAL",
+    })
+
+    const result = await builder
+      .transfer("bob.near", Amount.NEAR(1))
+      .send({ waitUntil: "INCLUDED_FINAL" })
+
+    expect(result.transaction).toBeDefined()
+    expect(result.transaction!.hash).toBeTruthy()
+  })
+
+  test("should not override transaction for EXECUTED_OPTIMISTIC", async () => {
+    const { builder, keyStore, rpc } = createBuilderWithMocks()
+
+    const keyPair = parseKey(TEST_PRIVATE_KEY)
+    await keyStore.add("alice.near", keyPair)
+
+    const expectedHash = "rpc_provided_hash_123"
+    ;(rpc as any).sendTransaction = async () => ({
+      final_execution_status: "EXECUTED_OPTIMISTIC",
+      status: { SuccessValue: "" },
+      transaction: {
+        hash: expectedHash,
+        signer_id: "alice.near",
+        receiver_id: "bob.near",
+        nonce: 101,
+        public_key: TEST_PUBLIC_KEY,
+        actions: [],
+        signature: "sig...",
+      },
+      transaction_outcome: {
+        id: "tx123",
+        outcome: {
+          logs: [],
+          receipt_ids: [],
+          gas_burnt: 1000000,
+          tokens_burnt: "0",
+          executor_id: "alice.near",
+          status: { SuccessValue: "" },
+        },
+      },
+      receipts_outcome: [],
+    })
+
+    const result = await builder
+      .transfer("bob.near", Amount.NEAR(1))
+      .send({ waitUntil: "EXECUTED_OPTIMISTIC" })
+
+    // Should use RPC-provided hash, not inject
+    expect(result.transaction.hash).toBe(expectedHash)
+  })
+})


### PR DESCRIPTION
…njection

Add new transaction signing capabilities:

- Add .sign() method that returns the builder with cached signed tx
- Add .getHash() method to access transaction hash after signing
- Add .serialize() method to get signed transaction bytes
- Inject minimal transaction fields (hash, signer_id, receiver_id, nonce) for NONE/INCLUDED/INCLUDED_FINAL responses
- Invalidate cache when actions are modified or signer changes
- Update .send() to use cached signed tx and support retry with fresh nonce

This enables offline signing workflows and ensures transaction.hash is always available for tracking, even with NONE finality.

Testing:
- Add 19 comprehensive unit tests for signing functionality
- Add integration tests for real network scenarios
- All existing tests continue to pass

Closes #25 