### PR TITLE
Refactor Near Class Constructor into Helper Methods

### DIFF
--- a/tests/unit/near-constructor.test.ts
+++ b/tests/unit/near-constructor.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Unit tests for Near class constructor refactoring
+ *
+ * Tests the private helper methods (_initializeRpc, _resolveKeyStore, _resolveSigner)
+ * indirectly through the Near constructor and public API.
+ */
+
+import { describe, expect, test } from "bun:test"
+import { Near } from "../../src/core/near.js"
+import { InMemoryKeyStore } from "../../src/keys/index.js"
+import type { KeyPair, Signer } from "../../src/core/types.js"
+import { generateKey } from "../../src/utils/key.js"
+
+describe("Near Constructor - RPC Initialization", () => {
+  test("_initializeRpc: uses default mainnet RPC URL", async () => {
+    const near = new Near({ network: "mainnet" })
+    const status = await near.getStatus()
+    expect(status.chainId).toBe("mainnet")
+  })
+
+  test("_initializeRpc: uses custom RPC URL", async () => {
+    const near = new Near({
+      network: "mainnet",
+      rpcUrl: "https://rpc.mainnet.near.org",
+    })
+    const status = await near.getStatus()
+    expect(status.chainId).toBe("mainnet")
+  })
+
+  test("_initializeRpc: uses testnet RPC URL", async () => {
+    const near = new Near({ network: "testnet" })
+    const status = await near.getStatus()
+    expect(status.chainId).toBe("testnet")
+  })
+
+  test("_initializeRpc: accepts custom headers and retry config", () => {
+    const near = new Near({
+      network: "mainnet",
+      headers: { "X-Custom-Header": "value" },
+      retryConfig: { maxRetries: 5, initialDelayMs: 200 },
+    })
+    // Constructor should not throw
+    expect(near).toBeDefined()
+  })
+})
+
+describe("Near Constructor - KeyStore Resolution", () => {
+  test("_resolveKeyStore: defaults to InMemoryKeyStore when no keyStore provided", async () => {
+    const near = new Near({ network: "mainnet" })
+    // Should have an empty in-memory keystore
+    const keys = await near["keyStore"].list()
+    expect(keys.length).toBe(0)
+  })
+
+  test("_resolveKeyStore: accepts KeyStore instance", async () => {
+    const customKeyStore = new InMemoryKeyStore()
+    const testKey = generateKey()
+    await customKeyStore.add("alice.near", testKey)
+
+    const near = new Near({
+      network: "mainnet",
+      keyStore: customKeyStore,
+    })
+
+    const key = await near["keyStore"].get("alice.near")
+    expect(key).not.toBeNull()
+    expect(key?.publicKey.toString()).toBe(testKey.publicKey.toString())
+  })
+
+  test("_resolveKeyStore: accepts Record of account->key mappings", async () => {
+    const testKey = generateKey()
+    const near = new Near({
+      network: "mainnet",
+      keyStore: {
+        "alice.near": testKey.secretKey,
+      },
+    })
+
+    const key = await near["keyStore"].get("alice.near")
+    expect(key).not.toBeNull()
+    expect(key?.publicKey.toString()).toBe(testKey.publicKey.toString())
+  })
+})
+
+describe("Near Constructor - Signer Resolution", () => {
+  test("_resolveSigner: accepts custom signer function", async () => {
+    const customSigner: Signer = async (message: Uint8Array) => {
+      // Mock signer that returns a fixed signature
+      return new Uint8Array(64).fill(1)
+    }
+
+    const near = new Near({
+      network: "mainnet",
+      signer: customSigner,
+    })
+
+    expect(near["signer"]).toBe(customSigner)
+  })
+
+  test("_resolveSigner: creates signer from privateKey string", () => {
+    const testKey = generateKey()
+    const near = new Near({
+      network: "mainnet",
+      privateKey: testKey.secretKey,
+    })
+
+    expect(near["signer"]).toBeDefined()
+    expect(typeof near["signer"]).toBe("function")
+  })
+
+  test("_resolveSigner: adds privateKey to keyStore for sandbox network", async () => {
+    const rootKey = generateKey()
+    const mockSandbox = {
+      rpcUrl: "http://127.0.0.1:12345",
+      networkId: "localnet",
+      rootAccount: {
+        id: "test.near",
+        secretKey: rootKey.secretKey,
+      },
+    }
+
+    const near = new Near({
+      network: mockSandbox,
+      privateKey: rootKey.secretKey,
+    })
+
+    // Should have added the key to keyStore for sandbox
+    const key = await near["keyStore"].get("test.near")
+    expect(key).not.toBeNull()
+    expect(key?.publicKey.toString()).toBe(rootKey.publicKey.toString())
+  })
+
+  test("_resolveSigner: auto-adds sandbox root key when no signer/privateKey", async () => {
+    const rootKey = generateKey()
+    const mockSandbox = {
+      rpcUrl: "http://127.0.0.1:12345",
+      networkId: "localnet",
+      rootAccount: {
+        id: "test.near",
+        secretKey: rootKey.secretKey,
+      },
+    }
+
+    const near = new Near({
+      network: mockSandbox,
+    })
+
+    // Should have set pendingKeyStoreInit for async keystore
+    expect(near["pendingKeyStoreInit"]).toBeDefined()
+
+    // After waiting, key should be in keyStore
+    await near["pendingKeyStoreInit"]
+
+    const key = await near["keyStore"].get("test.near")
+    expect(key).not.toBeNull()
+    expect(key?.publicKey.toString()).toBe(rootKey.publicKey.toString())
+  })
+
+  test("_resolveSigner: doesn't auto-add when explicit signer provided", async () => {
+    const rootKey = generateKey()
+    const mockSandbox = {
+      rpcUrl: "http://127.0.0.1:12345",
+      networkId: "localnet",
+      rootAccount: {
+        id: "test.near",
+        secretKey: rootKey.secretKey,
+      },
+    }
+
+    const customSigner: Signer = async (message: Uint8Array) => {
+      return new Uint8Array(64).fill(1)
+    }
+
+    const near = new Near({
+      network: mockSandbox,
+      signer: customSigner,
+    })
+
+    // Should NOT have pending init when explicit signer provided
+    expect(near["pendingKeyStoreInit"]).toBeUndefined()
+  })
+
+  test("_resolveSigner: doesn't auto-add when sandbox missing secretKey", async () => {
+    const mockSandbox = {
+      rpcUrl: "http://127.0.0.1:12345",
+      networkId: "localnet",
+      rootAccount: {
+        id: "test.near",
+        // No secretKey - sanitized config
+      },
+    }
+
+    const near = new Near({
+      network: mockSandbox,
+    })
+
+    // Should NOT have pending init when secretKey missing
+    expect(near["pendingKeyStoreInit"]).toBeUndefined()
+  })
+})
+
+describe("Near Constructor - Default Configuration", () => {
+  test("sets defaultWaitUntil correctly", () => {
+    const near1 = new Near({ network: "mainnet" })
+    expect(near1["defaultWaitUntil"]).toBe("EXECUTED_OPTIMISTIC")
+
+    const near2 = new Near({
+      network: "mainnet",
+      defaultWaitUntil: "FINAL",
+    })
+    expect(near2["defaultWaitUntil"]).toBe("FINAL")
+  })
+
+  test("stores wallet connection", () => {
+    const mockWallet = {
+      getAccounts: async () => [{ accountId: "alice.near" }],
+      signAndSendTransaction: async () => {},
+    }
+
+    const near = new Near({
+      network: "mainnet",
+      wallet: mockWallet,
+    })
+
+    expect(near["wallet"]).toBe(mockWallet)
+  })
+})


### PR DESCRIPTION
Break down the Near class constructor's initialization logic into three private helper methods for improved readability and maintainability:

- _initializeRpc(): Handles RPC client setup from network config
- _resolveKeyStore(): Manages keystore initialization
- _resolveSigner(): Handles signer resolution including privateKey and sandbox root key auto-detection

This refactoring separates concerns and makes the initialization process easier to follow and test. Added comprehensive unit tests to verify the behavior of each helper method.

Changes:
- Extracted constructor logic into 3 private helper methods
- Added JSDoc comments for each helper method
- Added 15 new unit tests covering all helper method scenarios
- No functional changes, only code organization improvements