### PR TITLE
Consolidate RPC error handling logic

### DIFF
--- a/src/core/rpc/rpc.ts
+++ b/src/core/rpc/rpc.ts
@@ -4,8 +4,6 @@
 
 import { base64 } from "@scure/base"
 import {
-  AccessKeyDoesNotExistError,
-  FunctionCallError,
   InvalidTransactionError,
   NearError,
   NetworkError,
@@ -26,6 +24,7 @@ import {
   checkOutcomeForFunctionCallError,
   extractErrorMessage,
   isRetryableStatus,
+  parseQueryError,
   parseRpcError,
 } from "./rpc-error-handler.js"
 import {
@@ -206,10 +205,7 @@ export class RpcClient {
     })
 
     // Check for errors in result (NEAR returns view function errors this way)
-    if (result && typeof result === "object" && "error" in result) {
-      const errorMsg = (result as { error: string }).error
-      throw new FunctionCallError(contractId, methodName, errorMsg)
-    }
+    parseQueryError(result, { contractId, methodName })
 
     return ViewFunctionCallResultSchema.parse(result)
   }
@@ -236,14 +232,7 @@ export class RpcClient {
     })
 
     // Check for errors in result (NEAR returns access key errors this way)
-    if (result && typeof result === "object" && "error" in result) {
-      const errorMsg = (result as { error: string }).error
-      // Check if it's an access key not found error
-      if (errorMsg.includes("does not exist")) {
-        throw new AccessKeyDoesNotExistError(accountId, publicKey)
-      }
-      throw new NetworkError(`Query error: ${errorMsg}`)
-    }
+    parseQueryError(result, { accountId, publicKey })
 
     return AccessKeyViewSchema.parse(result)
   }

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -273,25 +273,6 @@ export class NodeNotSyncedError extends NearError {
 }
 
 /**
- * Thrown when access key is not found
- */
-export class UnknownAccessKeyError extends NearError {
-  accountId: string
-  publicKey: string
-
-  constructor(accountId: string, publicKey: string) {
-    super(
-      `Access key not found: ${publicKey} for account ${accountId}`,
-      "UNKNOWN_ACCESS_KEY",
-    )
-    this.name = "UnknownAccessKeyError"
-    this.accountId = accountId
-    this.publicKey = publicKey
-    Object.setPrototypeOf(this, UnknownAccessKeyError.prototype)
-  }
-}
-
-/**
  * Thrown when an account has no contract deployed
  */
 export class ContractNotDeployedError extends NearError {


### PR DESCRIPTION
Extract query error handling into parseQueryError() function to eliminate code duplication between getAccessKey() and viewFunction().

Changes:
- Add parseQueryError() in rpc-error-handler.ts for result.error handling
- Remove inline error handling from getAccessKey() and viewFunction()
- Remove UnknownAccessKeyError (unreachable dead code)
- Use AccessKeyDoesNotExistError consistently for access key errors

The UnknownAccessKeyError class was never actually thrown because it relied on parseRpcError(), which only runs when data.error exists. Query methods return errors in result.error instead, making that handler unreachable.

This consolidation reduces ~50 lines of duplicated error handling logic and establishes a clear pattern: query errors use result.error, RPC errors use top-level error field.