### PR TITLE
Fix linting and type checking errors

### DIFF
--- a/src/core/near.ts
+++ b/src/core/near.ts
@@ -31,8 +31,8 @@ import type {
 } from "./types.js"
 
 export class Near {
-  private rpc: RpcClient
-  private keyStore: KeyStore
+  private rpc!: RpcClient
+  private keyStore!: KeyStore
   private signer?: Signer
   private wallet?: WalletConnection
   private defaultSignerId?: string
@@ -55,7 +55,9 @@ export class Near {
    * Initialize RPC client from configuration
    * @internal
    */
-  private _initializeRpc(validatedConfig: ReturnType<typeof NearConfigSchema.parse>): void {
+  private _initializeRpc(
+    validatedConfig: ReturnType<typeof NearConfigSchema.parse>,
+  ): void {
     const networkConfig = resolveNetworkConfig(validatedConfig.network)
     const rpcUrl = validatedConfig.rpcUrl || networkConfig.rpcUrl
     this.rpc = new RpcClient(
@@ -69,7 +71,9 @@ export class Near {
    * Resolve and initialize keystore from configuration
    * @internal
    */
-  private _resolveKeyStore(validatedConfig: ReturnType<typeof NearConfigSchema.parse>): void {
+  private _resolveKeyStore(
+    validatedConfig: ReturnType<typeof NearConfigSchema.parse>,
+  ): void {
     this.keyStore = this.resolveKeyStore(validatedConfig.keyStore)
   }
 

--- a/src/core/rpc/rpc-error-handler.ts
+++ b/src/core/rpc/rpc-error-handler.ts
@@ -258,7 +258,11 @@ export function parseQueryError(
 
   // Function call errors (method not found, execution failures, etc.)
   if (context.contractId) {
-    throw new FunctionCallError(context.contractId, context.methodName, errorMsg)
+    throw new FunctionCallError(
+      context.contractId,
+      context.methodName,
+      errorMsg,
+    )
   }
 
   // Generic query error


### PR DESCRIPTION
- Add definite assignment assertions to Near class properties (rpc, keyStore)
- Fix formatting issues with long function parameter lists
- Fix unused import (KeyPair) in test file
- Fix unused parameters in test Signer functions by prefixing with underscore
- Fix Signer mock functions to return proper Signature type with keyType and data
- Add type assertions for privateKey assignments in tests
- Fix WalletConnection mock to return proper FinalExecutionOutcome type
- Organize imports according to Biome linter requirements

All lint and typecheck issues now resolved with no warnings.