### PR TITLE
Set up basic CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,56 @@ jobs:
       - name: Run lint
         run: bun run lint
 
-      - name: Run tests
-        run: bun test
+  unit-tests:
+    runs-on: arc-runner-set
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run unit tests
+        run: bun test tests/unit
+
+  integration-tests:
+    runs-on: arc-runner-set
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Configure file descriptor limits for sandbox
+        run: ulimit -n 65535
+
+      - name: Run integration tests
+        run: bun test tests/integration
+
+  wallet-tests:
+    runs-on: arc-runner-set
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run wallet tests
+        run: bun test tests/wallets


### PR DESCRIPTION
Configure CI pipeline to run on pushes and pull requests to main:
- TypeScript type checking
- Biome linting
- Bun test suite

Uses arc-runner-set for workflow execution.

Closes #15 