### PR TITLE
Add finality parameter to RPC queries

### DIFF
--- a/src/contracts/contract.ts
+++ b/src/contracts/contract.ts
@@ -2,6 +2,7 @@
  * Type-safe contract interface
  */
 
+import type { BlockReference } from "../core/config-schemas.js"
 import type { Near } from "../core/near.js"
 import type { CallOptions } from "../core/types.js"
 
@@ -9,11 +10,14 @@ import type { CallOptions } from "../core/types.js"
  * Contract method interface
  *
  * Methods can be defined as:
- * - View methods: (args?: ArgsType | Uint8Array) => Promise<ReturnType>
+ * - View methods: (args?: ArgsType | Uint8Array, options?: BlockReference) => Promise<ReturnType>
  * - Call methods: (args?: ArgsType | Uint8Array, options?: CallOptions) => Promise<ReturnType>
  */
 export interface ContractMethods {
-  view: Record<string, (args?: unknown) => Promise<unknown>>
+  view: Record<
+    string,
+    (args?: unknown, options?: BlockReference) => Promise<unknown>
+  >
   call: Record<
     string,
     (args?: unknown, options?: CallOptions) => Promise<unknown>
@@ -32,8 +36,11 @@ export function createContract<T extends ContractMethods>(
       {},
       {
         get: (_target, methodName: string) => {
-          return async (args?: object | Uint8Array) => {
-            return await near.view(contractId, methodName, args || {})
+          return async (
+            args?: object | Uint8Array,
+            options?: BlockReference,
+          ) => {
+            return await near.view(contractId, methodName, args || {}, options)
           }
         },
       },

--- a/src/core/config-schemas.ts
+++ b/src/core/config-schemas.ts
@@ -49,6 +49,62 @@ export const CallOptionsSchema = z.object({
 
 export type CallOptions = z.infer<typeof CallOptionsSchema>
 
+// ==================== Block Reference Schema ====================
+
+/**
+ * Block reference for RPC queries
+ *
+ * Specify either `finality` OR `blockId` (not both).
+ * If both are provided, `blockId` takes precedence.
+ *
+ * @example
+ * ```typescript
+ * // Query at final block (default)
+ * await near.view('contract.near', 'get_value')
+ *
+ * // Query at optimistic for latest state
+ * await near.view('contract.near', 'get_value', {}, {
+ *   finality: 'optimistic'
+ * })
+ *
+ * // Query at specific block height
+ * await near.view('contract.near', 'get_value', {}, {
+ *   blockId: 27912554
+ * })
+ *
+ * // Query at specific block hash
+ * await near.view('contract.near', 'get_value', {}, {
+ *   blockId: '3Xz2wM9rigMXzA2c5vgCP8wTgFBaePucgUmVYPkMqhRL'
+ * })
+ * ```
+ */
+export const BlockReferenceSchema = z.object({
+  /**
+   * Finality level for the query
+   *
+   * - `optimistic`: Block that might be skipped (~1s after submission). Use for latest state.
+   * - `near-final`: Irreversible unless a validator is slashed (~2s after submission)
+   * - `final`: Fully finalized and irreversible (~3s after submission). DEFAULT for view calls.
+   *
+   * @default "final" for view calls, "optimistic" for account/key queries
+   * @see https://docs.near.org/api/rpc/setup#using-finality-param
+   */
+  finality: z.enum(["optimistic", "near-final", "final"]).optional(),
+
+  /**
+   * Block ID to query at - can be block number or block hash
+   *
+   * Use block number (e.g., `27912554`) or block hash
+   * (e.g., `'3Xz2wM9rigMXzA2c5vgCP8wTgFBaePucgUmVYPkMqhRL'`) to query
+   * historical state.
+   *
+   * Mutually exclusive with `finality`. If both are provided, `blockId` takes precedence.
+   */
+  blockId: z.union([z.number(), z.string()]).optional(),
+})
+
+export type BlockReference = z.infer<typeof BlockReferenceSchema>
+
 // ==================== Near Config Schema ====================
 
 /**

--- a/src/core/near.ts
+++ b/src/core/near.ts
@@ -12,6 +12,7 @@ import type { Amount } from "../utils/validation.js"
 import { normalizeAmount, normalizeGas } from "../utils/validation.js"
 import * as actions from "./actions.js"
 import {
+  type BlockReference,
   type NearConfig,
   NearConfigSchema,
   resolveNetworkConfig,
@@ -204,8 +205,14 @@ export class Near {
     contractId: string,
     methodName: string,
     args: object | Uint8Array = {},
+    options?: BlockReference,
   ): Promise<T> {
-    const result = await this.rpc.viewFunction(contractId, methodName, args)
+    const result = await this.rpc.viewFunction(
+      contractId,
+      methodName,
+      args,
+      options,
+    )
 
     // Decode result
     const resultBuffer = new Uint8Array(result.result)
@@ -386,9 +393,12 @@ export class Near {
   /**
    * Get account balance in NEAR
    */
-  async getBalance(accountId: string): Promise<string> {
+  async getBalance(
+    accountId: string,
+    options?: BlockReference,
+  ): Promise<string> {
     // RPC client now throws AccountDoesNotExistError directly
-    const account = await this.rpc.getAccount(accountId)
+    const account = await this.rpc.getAccount(accountId, options)
 
     // Convert yoctoNEAR to NEAR
     const balanceYocto = BigInt(account.amount)
@@ -400,9 +410,12 @@ export class Near {
   /**
    * Check if an account exists
    */
-  async accountExists(accountId: string): Promise<boolean> {
+  async accountExists(
+    accountId: string,
+    options?: BlockReference,
+  ): Promise<boolean> {
     try {
-      await this.rpc.getAccount(accountId)
+      await this.rpc.getAccount(accountId, options)
       return true
     } catch {
       return false


### PR DESCRIPTION
Add support for specifying finality level (optimistic, near-final, final) or specific block ID (block number or hash) when making RPC queries.

Changes:
- Add BlockReferenceSchema with comprehensive JSDoc documentation
- Update viewFunction, getAccount, getAccessKey in RPC layer
- Update view, getBalance, accountExists in Near client
- Update contract proxy to support BlockReference in view methods
- Default to "final" for view calls, "optimistic" for account/key queries
- blockId takes precedence if both finality and blockId are provided

Usage examples:
- Query at final block (default): near.view('contract.near', 'method')
- Query at optimistic: near.view('contract.near', 'method', {}, { finality: 'optimistic' })
- Query at specific block: near.view('contract.near', 'method', {}, { blockId: 27912554 })
- Query at block hash: near.view('contract.near', 'method', {}, { blockId: 'hash' })


Closes #27 