### PR TITLE
refactor(actions): redesign publishContract API with identifiedBy parameter

### DIFF
--- a/.changeset/publish-contract-identified-by.md
+++ b/.changeset/publish-contract-identified-by.md
@@ -1,0 +1,23 @@
+---
+"near-kit": patch
+---
+
+Redesign `publishContract` API with clearer `identifiedBy` parameter
+
+The `publishContract` method now uses an options object with `identifiedBy: "hash" | "account"` instead of the misleading `accountId` parameter. The default mode is now `"account"` (updatable contracts).
+
+**Migration guide:**
+
+```typescript
+// Before
+publishContract(wasm) // immutable (hash)
+publishContract(wasm, "factory.near") // updatable (account)
+
+// After
+publishContract(wasm) // updatable (account) - DEFAULT CHANGED
+publishContract(wasm, { identifiedBy: "hash" }) // immutable (hash)
+```
+
+This change makes it clear that:
+- `"account"` mode: Contract is updatable by the signer, identified by their account
+- `"hash"` mode: Contract is immutable, identified by its code hash

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "near",
@@ -15,7 +16,7 @@
         "zod": "^4.1.12",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.3.6",
+        "@biomejs/biome": "2.3.5",
         "@changesets/cli": "^2.29.7",
         "@hot-labs/near-connect": "^0.6.9",
         "@near-js/transactions": "^2.5.1",
@@ -41,23 +42,23 @@
 
     "@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.3.6", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.6", "@biomejs/cli-darwin-x64": "2.3.6", "@biomejs/cli-linux-arm64": "2.3.6", "@biomejs/cli-linux-arm64-musl": "2.3.6", "@biomejs/cli-linux-x64": "2.3.6", "@biomejs/cli-linux-x64-musl": "2.3.6", "@biomejs/cli-win32-arm64": "2.3.6", "@biomejs/cli-win32-x64": "2.3.6" }, "bin": { "biome": "bin/biome" } }, "sha512-oqUhWyU6tae0MFsr/7iLe++QWRg+6jtUhlx9/0GmCWDYFFrK366sBLamNM7D9Y+c7YSynUFKr8lpEp1r6Sk7eA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.3.5", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.5", "@biomejs/cli-darwin-x64": "2.3.5", "@biomejs/cli-linux-arm64": "2.3.5", "@biomejs/cli-linux-arm64-musl": "2.3.5", "@biomejs/cli-linux-x64": "2.3.5", "@biomejs/cli-linux-x64-musl": "2.3.5", "@biomejs/cli-win32-arm64": "2.3.5", "@biomejs/cli-win32-x64": "2.3.5" }, "bin": { "biome": "bin/biome" } }, "sha512-HvLhNlIlBIbAV77VysRIBEwp55oM/QAjQEin74QQX9Xb259/XP/D5AGGnZMOyF1el4zcvlNYYR3AyTMUV3ILhg=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-P4JWE5d8UayBxYe197QJwyW4ZHp0B+zvRIGCusOm1WbxmlhpAQA1zEqQuunHgSIzvyEEp4TVxiKGXNFZPg7r9Q=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fLdTur8cJU33HxHUUsii3GLx/TR0BsfQx8FkeqIiW33cGMtUD56fAtrh+2Fx1uhiCsVZlFh6iLKUU3pniZREQw=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-I4rTebj+F/L9K93IU7yTFs8nQ6EhaCOivxduRha4w4WEZK80yoZ8OAdR1F33m4yJ/NfUuTUbP/Wjs+vKjlCoWA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-qpT8XDqeUlzrOW8zb4k3tjhT7rmvVRumhi2657I2aGcY4B+Ft5fNwDdZGACzn8zj7/K1fdWjgwYE3i2mSZ+vOA=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-JjYy83eVBnvuINZiqyFO7xx72v8Srh4hsgaacSBCjC22DwM6+ZvnX1/fj8/SBiLuUOfZ8YhU2pfq2Dzakeyg1A=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-u/pybjTBPGBHB66ku4pK1gj+Dxgx7/+Z0jAriZISPX1ocTO8aHh8x8e7Kb1rB4Ms0nA/SzjtNOVJ4exVavQBCw=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-oK1NpIXIixbJ/4Tcx40cwiieqah6rRUtMGOHDeK2ToT7yUFVEvXUGRKqH0O4hqZ9tW8TcXNZKfgRH6xrsjVtGg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-eGUG7+hcLgGnMNl1KHVZUYxahYAhC462jF/wQolqu4qso2MSk32Q+QrpN7eN4jAHAg7FUMIo897muIhK4hXhqg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.6", "", { "os": "linux", "cpu": "x64" }, "sha512-ZjPXzy5yN9wusIoX+8Zp4p6cL8r0NzJCXg/4r1KLVveIPXd2jKVlqZ6ZyzEq385WwU3OX5KOwQYLQsOc788waQ=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.5", "", { "os": "linux", "cpu": "x64" }, "sha512-XrIVi9YAW6ye0CGQ+yax0gLfx+BFOtKaNX74n+xHWla6Cl6huUmcKNO7HPx7BiKnJUzrxXY1qYlm7xMvi08X4g=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.6", "", { "os": "linux", "cpu": "x64" }, "sha512-QvxB8GHQeaO4FCtwJpJjCgJkbHBbWxRHUxQlod+xeaYE6gtJdSkYkuxdKAQUZEOIsec+PeaDAhW9xjzYbwmOFA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.5", "", { "os": "linux", "cpu": "x64" }, "sha512-awVuycTPpVTH/+WDVnEEYSf6nbCBHf/4wB3lquwT7puhNg8R4XvonWNZzUsfHZrCkjkLhFH/vCZK5jHatD9FEg=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-YM7hLHpwjdt8R7+O2zS1Vo2cKgqEeptiXB1tWW1rgjN5LlpZovBVKtg7zfwfRrFx3i08aNZThYpTcowpTlczug=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-DlBiMlBZZ9eIq4H7RimDSGsYcOtfOIfZOaI5CqsWiSlbTfqbPVfWtCf92wNzx8GNMbu1s7/g3ZZESr6+GwM/SA=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.6", "", { "os": "win32", "cpu": "x64" }, "sha512-psgNEYgMAobY5h+QHRBVR9xvg2KocFuBKm6axZWB/aD12NWhQjiVFQUjV6wMXhlH4iT0Q9c3yK5JFRiDC/rzHA=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.5", "", { "os": "win32", "cpu": "x64" }, "sha512-nUmR8gb6yvrKhtRgzwo/gDimPwnO5a4sCydf8ZS2kHIJhEmSmk+STsusr1LHTuM//wXppBawvSQi2xFXJCdgKQ=="],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.0.13", "", { "dependencies": { "@changesets/config": "^3.1.1", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-BIW7bofD2yAWoE8H4V40FikC+1nNFEKBisMECccS16W1rt6qqhNTBDmIw5HaqmMgtLNz9e7oiALiEUuKrQ4oHg=="],
 
@@ -235,7 +236,7 @@
 
     "bn.js": ["bn.js@4.12.2", "", {}, "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="],
 
-    "borsh": ["borsh@2.0.0", "", {}, "sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg=="],
+    "borsh": ["borsh@1.0.0", "", {}, "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -547,19 +548,13 @@
 
     "@near-js/crypto/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
 
-    "@near-js/crypto/borsh": ["borsh@1.0.0", "", {}, "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ=="],
-
-    "@near-js/providers/borsh": ["borsh@1.0.0", "", {}, "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ=="],
-
     "@near-js/signers/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
-
-    "@near-js/signers/borsh": ["borsh@1.0.0", "", {}, "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ=="],
 
     "@near-js/transactions/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
 
-    "@near-js/transactions/borsh": ["borsh@1.0.0", "", {}, "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ=="],
-
     "@near-js/utils/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@near-wallet-selector/core/borsh": ["borsh@2.0.0", "", {}, "sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg=="],
 
     "@walletconnect/environment/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "bun test",
-    "lint": "biome check .",
+    "lint": "biome check . --write",
     "typecheck": "tsc --noEmit --project tsconfig.typecheck.json",
     "prepublishOnly": "bun run build",
     "release": "bun run build && changeset publish",
@@ -63,7 +63,7 @@
     }
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.6",
+    "@biomejs/biome": "2.3.5",
     "@changesets/cli": "^2.29.7",
     "@hot-labs/near-connect": "^0.6.9",
     "@near-js/transactions": "^2.5.1",

--- a/src/core/transaction.ts
+++ b/src/core/transaction.ts
@@ -354,27 +354,43 @@ export class TransactionBuilder {
   }
 
   /**
-   * Publish a global contract that can be reused by multiple accounts
+   * Publish a global contract that can be reused by multiple accounts.
    *
-   * @param code - The compiled contract code bytes
-   * @param publisherId - Optional account ID. If provided, creates a mutable contract (can be updated).
-   *                      If omitted, creates an immutable contract (identified by code hash).
+   * Global contracts are deployed once and referenced by multiple accounts,
+   * saving storage costs. Two modes are available:
+   *
+   * - **"account" (default)** - Contract is identified by the signer's account ID. The signer
+   *   can update the contract later, and all accounts using it will automatically
+   *   use the updated version. Use this when you need to push updates to users.
+   *
+   * - **"hash"** - Contract is identified by its code hash. This creates
+   *   an immutable contract that cannot be updated. Other accounts reference it by
+   *   the hash. Use this when you want guaranteed immutability.
+   *
+   * @param code - The compiled contract code bytes (WASM)
+   * @param options - Optional configuration
+   * @param options.identifiedBy - How the contract is identified and referenced:
+   *   - `"account"` (default): Updatable by signer, identified by signer's account ID
+   *   - `"hash"`: Immutable, identified by code hash
    *
    * @example
    * ```typescript
-   * // Publish immutable contract (identified by code hash)
+   * // Publish updatable contract (identified by your account) - default
    * await near.transaction(accountId)
    *   .publishContract(contractCode)
    *   .send()
    *
-   * // Publish mutable contract (identified by account, can be updated)
+   * // Publish immutable contract (identified by its hash)
    * await near.transaction(accountId)
-   *   .publishContract(contractCode, "my-publisher.near")
+   *   .publishContract(contractCode, { identifiedBy: "hash" })
    *   .send()
    * ```
    */
-  publishContract(code: Uint8Array, publisherId?: string): this {
-    this.actions.push(actions.publishContract(code, publisherId))
+  publishContract(
+    code: Uint8Array,
+    options?: { identifiedBy?: "hash" | "account" },
+  ): this {
+    this.actions.push(actions.publishContract(code, options))
 
     if (!this.receiverId) {
       this.receiverId = this.signerId

--- a/tests/integration/actions.test.ts
+++ b/tests/integration/actions.test.ts
@@ -422,7 +422,7 @@ describe("Transaction Actions - Integration Tests", () => {
       // Publish contract (mutable, identified by publisher account)
       await nearWithPublisherKey
         .transaction(publisherId)
-        .publishContract(contractCode, publisherId)
+        .publishContract(contractCode, { identifiedBy: "account" })
         .send()
 
       console.log(`✓ Contract published by: ${publisherId}`)
@@ -469,7 +469,7 @@ describe("Transaction Actions - Integration Tests", () => {
 
       await nearWithPublisherKey
         .transaction(publisherId)
-        .publishContract(contractCode, publisherId)
+        .publishContract(contractCode, { identifiedBy: "account" })
         .send()
 
       console.log(`✓ Contract published`)

--- a/tests/unit/schema-edge-cases.test.ts
+++ b/tests/unit/schema-edge-cases.test.ts
@@ -352,7 +352,7 @@ describe("Signature Types - Edge Cases", () => {
 // ==================== Global Contract Actions ====================
 
 describe("Global Contract Actions - Serialization", () => {
-  test("publishContract with CodeHash mode (immutable)", () => {
+  test("publishContract with AccountId mode (default, updatable)", () => {
     const code = new Uint8Array([
       0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
     ])
@@ -360,22 +360,22 @@ describe("Global Contract Actions - Serialization", () => {
 
     expect("deployGlobalContract" in action).toBe(true)
     expect(action.deployGlobalContract.code).toEqual(code)
-    expect(action.deployGlobalContract.deployMode).toEqual({ CodeHash: {} })
+    expect(action.deployGlobalContract.deployMode).toEqual({ AccountId: {} })
 
     // Should serialize successfully
     const serialized = ActionSchema.serialize(action)
     expect(serialized).toBeInstanceOf(Uint8Array)
   })
 
-  test("publishContract with AccountId mode (mutable)", () => {
+  test("publishContract with CodeHash mode (immutable)", () => {
     const code = new Uint8Array([
       0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
     ])
-    const action = publishContract(code, "publisher.near")
+    const action = publishContract(code, { identifiedBy: "hash" })
 
     expect("deployGlobalContract" in action).toBe(true)
     expect(action.deployGlobalContract.code).toEqual(code)
-    expect(action.deployGlobalContract.deployMode).toEqual({ AccountId: {} })
+    expect(action.deployGlobalContract.deployMode).toEqual({ CodeHash: {} })
 
     // Should serialize successfully
     const serialized = ActionSchema.serialize(action)
@@ -457,7 +457,7 @@ describe("Complex Action Combinations", () => {
           BigInt(0),
         ),
         addKey(pk, { fullAccess: {} }),
-        publishContract(code, "publisher.near"),
+        publishContract(code, { identifiedBy: "account" }),
         deployFromPublished({ accountId: "publisher.near" }),
       ],
     }


### PR DESCRIPTION
Replace misleading accountId parameter with explicit identifiedBy option.

The accountId parameter was confusing because it suggested deploying to another account, but actually only controlled the deploy mode flag.

Changes:
  - `publishContract(code, { identifiedBy: "hash" | "account" })`
  - Default changed from "hash" to "account" (updatable contracts)
  - Updated all tests and documentation
  - Fixed biome version to 2.3.5 to avoid false positive lint warnings