### PR TITLE
feat(nep413): add timestamp-based nonce with automatic expiration

### DIFF
--- a/.changeset/nep413-improvements.md
+++ b/.changeset/nep413-improvements.md
@@ -1,0 +1,11 @@
+---
+"near-kit": patch
+---
+
+Improve NEP-413 message signing with timestamp-based nonce generation and automatic expiration
+
+- Add `generateNonce()` helper that embeds timestamp in nonce (first 8 bytes)
+- Add `maxAge` parameter to `verifyNep413Signature()` for automatic expiration checking (default: 5 minutes)
+- Add `callbackUrl` and `state` fields to `SignMessageParams` and `SignedMessage` per NEP-413 spec
+- Add comprehensive TSDoc to NEP-413 functions explaining security considerations
+- Reduce nonce storage burden: only need to track nonces within the `maxAge` window instead of forever

--- a/examples/sign-in-with-near.ts
+++ b/examples/sign-in-with-near.ts
@@ -6,7 +6,7 @@
  */
 
 import {
-  generateNep413Nonce,
+  generateNonce,
   Near,
   type PrivateKey,
   type SignedMessage,
@@ -29,7 +29,7 @@ async function clientSignMessage() {
   })
 
   // Generate a random nonce for replay protection
-  const nonce = generateNep413Nonce()
+  const nonce = generateNonce()
 
   // Sign the message (no gas cost)
   const signedMessage = await near.signMessage({

--- a/src/core/near.ts
+++ b/src/core/near.ts
@@ -7,7 +7,7 @@ import { createContract } from "../contracts/contract.js"
 import { NearError } from "../errors/index.js"
 import { InMemoryKeyStore } from "../keys/index.js"
 import { parseKey } from "../utils/key.js"
-import { generateNep413Nonce } from "../utils/nep413.js"
+import { generateNonce } from "../utils/nep413.js"
 import type { Amount, Gas } from "../utils/validation.js"
 import { normalizeAmount, normalizeGas } from "../utils/validation.js"
 import * as actions from "./actions.js"
@@ -448,7 +448,7 @@ export class Near {
     // Add nonce if not provided
     const fullParams: SignMessageParams = {
       ...params,
-      nonce: "nonce" in params ? params.nonce : generateNep413Nonce(),
+      nonce: "nonce" in params ? params.nonce : generateNonce(),
     }
 
     // Try wallet first if available

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -323,21 +323,37 @@ export interface WalletAccount {
 }
 
 /**
- * Parameters for signing a message
+ * Parameters for signing a message (NEP-413)
+ *
+ * @see https://github.com/near/NEPs/blob/master/neps/nep-0413.md
  */
 export interface SignMessageParams {
+  /** The message that wants to be transmitted */
   message: string
+  /** The recipient to whom the message is destined (e.g. "alice.near" or "myapp.com") */
   recipient: string
+  /** A nonce that uniquely identifies this instance of the message (32 bytes) */
   nonce: Uint8Array
+  /** Optional, applicable to browser wallets. The URL to call after the signing process */
+  callbackUrl?: string
+  /** Optional, applicable to browser wallets. A state for CSRF protection */
+  state?: string
 }
 
 /**
- * Signed message result
+ * Signed message result (NEP-413)
+ *
+ * @see https://github.com/near/NEPs/blob/master/neps/nep-0413.md
  */
 export interface SignedMessage {
+  /** The account name to which the publicKey corresponds */
   accountId: string
+  /** The public key used to sign, in format "<key-type>:<base58-key-bytes>" */
   publicKey: string
+  /** The base64 representation of the signature */
   signature: string
+  /** Optional state returned from browser wallets (for CSRF protection) */
+  state?: string
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export {
   formatGas,
   Gas,
   generateKey,
-  generateNep413Nonce,
+  generateNonce,
   generateSeedPhrase,
   isPrivateKey,
   isValidAccountId,
@@ -87,6 +87,7 @@ export {
   parseGas,
   parseKey,
   parseSeedPhrase,
+  type VerifyNep413Options,
   validatePrivateKey,
   verifyNep413Signature,
 } from "./utils/index.js"

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,9 +15,10 @@ export {
 export { formatGas, Gas, type GasInput, parseGas } from "./gas.js"
 export * from "./key.js"
 export {
-  generateNep413Nonce,
+  generateNonce,
   NEP413_TAG,
   serializeNep413Message,
+  type VerifyNep413Options,
   verifyNep413Signature,
 } from "./nep413.js"
 export {

--- a/tests/unit/near-sign-message.test.ts
+++ b/tests/unit/near-sign-message.test.ts
@@ -18,7 +18,7 @@ import type {
 import { InMemoryKeyStore } from "../../src/keys/index.js"
 import {
   Ed25519KeyPair,
-  generateNep413Nonce,
+  generateNonce,
   verifyNep413Signature,
 } from "../../src/utils/index.js"
 
@@ -33,7 +33,7 @@ describe("Near.signMessage() - Keystore-based signing", () => {
       keyStore,
     })
 
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
     const params: SignMessageParams = {
       message: "Login to MyApp",
       recipient: "myapp.near",
@@ -88,7 +88,7 @@ describe("Near.signMessage() - Keystore-based signing", () => {
       defaultSignerId: "alice.near",
     })
 
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
     const params: SignMessageParams = {
       message: "Login to MyApp",
       recipient: "myapp.near",
@@ -112,7 +112,7 @@ describe("Near.signMessage() - Keystore-based signing", () => {
     const params: SignMessageParams = {
       message: "Login to MyApp",
       recipient: "myapp.near",
-      nonce: generateNep413Nonce(),
+      nonce: generateNonce(),
     }
 
     await expect(
@@ -142,7 +142,7 @@ describe("Near.signMessage() - Keystore-based signing", () => {
     const params: SignMessageParams = {
       message: "Login to MyApp",
       recipient: "myapp.near",
-      nonce: generateNep413Nonce(),
+      nonce: generateNonce(),
     }
 
     await expect(
@@ -154,7 +154,7 @@ describe("Near.signMessage() - Keystore-based signing", () => {
 describe("Near.signMessage() - Wallet-based signing", () => {
   test("should use wallet.signMessage when available", async () => {
     const keyPair = Ed25519KeyPair.fromRandom()
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
 
     const mockWallet: WalletConnection = {
       async getAccounts() {
@@ -213,7 +213,7 @@ describe("Near.signMessage() - Wallet-based signing", () => {
       keyStore,
     })
 
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
     const params: SignMessageParams = {
       message: "Login to MyApp",
       recipient: "myapp.near",
@@ -253,7 +253,7 @@ describe("Near.signMessage() - Wallet-based signing", () => {
       keyStore,
     })
 
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
     const params: SignMessageParams = {
       message: "Login to MyApp",
       recipient: "myapp.near",
@@ -283,7 +283,7 @@ describe("Near.signMessage() - Edge cases", () => {
       keyStore,
     })
 
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
     const params: SignMessageParams = {
       message: "",
       recipient: "myapp.near",
@@ -307,7 +307,7 @@ describe("Near.signMessage() - Edge cases", () => {
       keyStore,
     })
 
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
     const params: SignMessageParams = {
       message: "こんにちは世界 🌍 Привет мир",
       recipient: "myapp.near",
@@ -331,7 +331,7 @@ describe("Near.signMessage() - Edge cases", () => {
       keyStore,
     })
 
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
     const params: SignMessageParams = {
       message: "A".repeat(10000),
       recipient: "myapp.near",

--- a/tests/unit/nep413.test.ts
+++ b/tests/unit/nep413.test.ts
@@ -7,7 +7,7 @@ import { base58, base64 } from "@scure/base"
 import type { SignMessageParams } from "../../src/core/types.js"
 import {
   Ed25519KeyPair,
-  generateNep413Nonce,
+  generateNonce,
   NEP413_TAG,
   Secp256k1KeyPair,
   serializeNep413Message,
@@ -16,7 +16,7 @@ import {
 
 describe("NEP-413 Message Signing", () => {
   test("should generate a 32-byte nonce", () => {
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
     expect(nonce).toBeInstanceOf(Uint8Array)
     expect(nonce.length).toBe(32)
   })
@@ -51,7 +51,7 @@ describe("NEP-413 Message Signing", () => {
   test("should sign and verify message correctly", () => {
     const keyPair = Ed25519KeyPair.fromRandom()
     const accountId = "test.near"
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
 
     const params: SignMessageParams = {
       message: "Login to MyApp",
@@ -75,7 +75,7 @@ describe("NEP-413 Message Signing", () => {
   test("should fail verification with wrong message", () => {
     const keyPair = Ed25519KeyPair.fromRandom()
     const accountId = "test.near"
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
 
     const params: SignMessageParams = {
       message: "Login to MyApp",
@@ -99,7 +99,7 @@ describe("NEP-413 Message Signing", () => {
   test("should fail verification with wrong nonce", () => {
     const keyPair = Ed25519KeyPair.fromRandom()
     const accountId = "test.near"
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
 
     const params: SignMessageParams = {
       message: "Login to MyApp",
@@ -110,7 +110,7 @@ describe("NEP-413 Message Signing", () => {
     const signedMessage = keyPair.signNep413Message(accountId, params)
 
     // Try to verify with different nonce
-    const differentNonce = generateNep413Nonce()
+    const differentNonce = generateNonce()
     const differentParams: SignMessageParams = {
       message: "Login to MyApp",
       recipient: "myapp.near",
@@ -124,7 +124,7 @@ describe("NEP-413 Message Signing", () => {
   test("should fail verification with wrong recipient", () => {
     const keyPair = Ed25519KeyPair.fromRandom()
     const accountId = "test.near"
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
 
     const params: SignMessageParams = {
       message: "Login to MyApp",
@@ -172,7 +172,7 @@ describe("NEP-413 Message Signing", () => {
   test("should handle empty message", () => {
     const keyPair = Ed25519KeyPair.fromRandom()
     const accountId = "test.near"
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
 
     const params: SignMessageParams = {
       message: "",
@@ -188,7 +188,7 @@ describe("NEP-413 Message Signing", () => {
   test("should handle long message", () => {
     const keyPair = Ed25519KeyPair.fromRandom()
     const accountId = "test.near"
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
 
     const params: SignMessageParams = {
       message: "A".repeat(10000), // Very long message
@@ -204,7 +204,7 @@ describe("NEP-413 Message Signing", () => {
   test("should handle unicode characters in message", () => {
     const keyPair = Ed25519KeyPair.fromRandom()
     const accountId = "test.near"
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
 
     const params: SignMessageParams = {
       message: "こんにちは世界 🌍 Привет мир",
@@ -220,7 +220,7 @@ describe("NEP-413 Message Signing", () => {
   test("should reject non-Ed25519 keys (secp256k1) for NEP-413 verification", () => {
     const keyPair = Secp256k1KeyPair.fromRandom()
     const accountId = "test.near"
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
 
     const params: SignMessageParams = {
       message: "Login to MyApp",
@@ -239,7 +239,7 @@ describe("NEP-413 Message Signing", () => {
   test("should verify base58-encoded signature with ed25519 prefix", () => {
     const keyPair = Ed25519KeyPair.fromRandom()
     const accountId = "test.near"
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
 
     const params: SignMessageParams = {
       message: "Login to MyApp",
@@ -269,7 +269,7 @@ describe("NEP-413 Message Signing", () => {
   test("should use base58 fallback when base64 decode fails", () => {
     const keyPair = Ed25519KeyPair.fromRandom()
     const accountId = "test.near"
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
 
     const params: SignMessageParams = {
       message: "Login to MyApp",
@@ -299,7 +299,7 @@ describe("NEP-413 Message Signing", () => {
   test("should return false when both base64 and base58 decoding fail", () => {
     const keyPair = Ed25519KeyPair.fromRandom()
     const accountId = "test.near"
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
 
     const params: SignMessageParams = {
       message: "Login to MyApp",
@@ -325,7 +325,7 @@ describe("NEP-413 Message Signing", () => {
   test("should return false when public key parsing fails", () => {
     const keyPair = Ed25519KeyPair.fromRandom()
     const accountId = "test.near"
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
 
     const params: SignMessageParams = {
       message: "Login to MyApp",
@@ -351,7 +351,7 @@ describe("NEP-413 Message Signing", () => {
   test("should return false when signature verification fails", () => {
     const keyPair = Ed25519KeyPair.fromRandom()
     const accountId = "test.near"
-    const nonce = generateNep413Nonce()
+    const nonce = generateNonce()
 
     const params: SignMessageParams = {
       message: "Login to MyApp",


### PR DESCRIPTION
## Summary

- Replace `generateNep413Nonce()` with improved `generateNonce()` that embeds timestamp
- Add automatic expiration checking to `verifyNep413Signature()` (default: 5 minutes)
- Add `callbackUrl` and `state` fields per NEP-413 spec
- Reduce nonce storage burden: only track nonces within expiration window

## Test plan

- [x] Unit tests pass
- [x] Typecheck passes
- [x] Lint passes