### PR TITLE
fix(sandbox): prevent port collision in parallel execution

### DIFF
--- a/.changeset/fix-parallel-sandbox-port-collision.md
+++ b/.changeset/fix-parallel-sandbox-port-collision.md
@@ -1,0 +1,7 @@
+---
+"near-kit": patch
+---
+
+Fix port collision when running sandboxes in parallel
+
+When multiple sandboxes start simultaneously, assigning network port as `rpcPort + 1` caused conflicts. Sandbox A's network port would collide with Sandbox B's RPC port, preventing the second sandbox from binding successfully on macOS.

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -111,8 +111,9 @@ export class Sandbox {
     }
 
     // 5. Start sandbox process
+    // Find two separate available ports to avoid conflicts when running in parallel
     const port = await findAvailablePort()
-    const networkPort = port + 1
+    const networkPort = await findAvailablePort()
     const childProcess = spawn(
       binaryPath,
       [


### PR DESCRIPTION
Fixes port conflicts when running multiple sandboxes in parallel.

## Problem

When sandboxes start simultaneously, the previous code assigned ports as:
- Sandbox A: RPC=N, Network=N+1
- Sandbox B: RPC=N+1, Network=N+2

This caused Sandbox B's RPC port to collide with Sandbox A's network port.

## Solution

Find two separate available ports instead of assuming port+1 is free.

## Testing

Verified parallel sandbox startup works on macOS where it previously timed out.