### PR TITLE
fix(nep413): switch NEP-413 signatures to base58 prefixes

### DIFF
--- a/.changeset/bright-geese-sin.md
+++ b/.changeset/bright-geese-sin.md
@@ -1,0 +1,5 @@
+---
+"near-kit": patch
+---
+
+Switch NEP-413 signatures to key-type-prefixed base58 encoding for both Ed25519 and Secp256k1, while retaining legacy verification support.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -350,7 +350,7 @@ export interface SignedMessage {
   accountId: string
   /** The public key used to sign, in format "<key-type>:<base58-key-bytes>" */
   publicKey: string
-  /** The base64 representation of the signature */
+  /** The base58 signature prefixed with the key type (e.g., "ed25519:...") */
   signature: string
   /** Optional state returned from browser wallets (for CSRF protection) */
   state?: string

--- a/src/utils/key.ts
+++ b/src/utils/key.ts
@@ -1,6 +1,6 @@
 import { ed25519 } from "@noble/curves/ed25519.js"
 import { secp256k1 } from "@noble/curves/secp256k1.js"
-import { base58, base64 } from "@scure/base"
+import { base58 } from "@scure/base"
 import { HDKey } from "@scure/bip32"
 import * as bip39 from "@scure/bip39"
 import { wordlist } from "@scure/bip39/wordlists/english.js"
@@ -58,7 +58,7 @@ export class Ed25519KeyPair implements KeyPair {
    *
    * @param accountId - The NEAR account ID that owns this key
    * @param params - Message signing parameters (message, recipient, nonce)
-   * @returns Signed message with account ID, public key, and base64-encoded signature
+   * @returns Signed message with account ID, public key, and base58-encoded signature prefixed with `ed25519:`
    *
    * @see https://github.com/near/NEPs/blob/master/neps/nep-0413.md
    *
@@ -70,7 +70,7 @@ export class Ed25519KeyPair implements KeyPair {
    *   recipient: "myapp.near",
    *   nonce,
    * })
-   * console.log(signedMessage.signature) // Base64-encoded signature
+   * console.log(signedMessage.signature) // Base58-encoded signature
    * ```
    */
   signNep413Message(
@@ -83,11 +83,11 @@ export class Ed25519KeyPair implements KeyPair {
     // Sign the hash
     const signature = ed25519.sign(hash, this.privateKey)
 
-    // Return signed message with base64-encoded signature
+    // Return signed message with base58-encoded signature (ed25519:... prefix)
     return {
       accountId,
       publicKey: this.publicKey.toString(),
-      signature: base64.encode(signature),
+      signature: `${ED25519_KEY_PREFIX}${base58.encode(signature)}`,
     }
   }
 
@@ -159,7 +159,7 @@ export class Secp256k1KeyPair implements KeyPair {
    *
    * @param accountId - The NEAR account ID that owns this key
    * @param params - Message signing parameters (message, recipient, nonce)
-   * @returns Signed message with account ID, public key, and base64-encoded signature
+   * @returns Signed message with account ID, public key, and base58-encoded signature prefixed with `secp256k1:`
    *
    * @see https://github.com/near/NEPs/blob/master/neps/nep-0413.md
    *
@@ -171,7 +171,7 @@ export class Secp256k1KeyPair implements KeyPair {
    *   recipient: "myapp.near",
    *   nonce,
    * })
-   * console.log(signedMessage.signature) // Base64-encoded signature
+   * console.log(signedMessage.signature) // Base58-encoded signature
    * ```
    */
   signNep413Message(
@@ -186,11 +186,11 @@ export class Secp256k1KeyPair implements KeyPair {
       format: "recovered",
     })
 
-    // Return signed message with base64-encoded signature
+    // Return signed message with base58-encoded signature (secp256k1:... prefix)
     return {
       accountId,
       publicKey: this.publicKey.toString(),
-      signature: base64.encode(signature),
+      signature: `${SECP256K1_KEY_PREFIX}${base58.encode(signature)}`,
     }
   }
 

--- a/tests/unit/key-utils.test.ts
+++ b/tests/unit/key-utils.test.ts
@@ -448,7 +448,7 @@ describe("NEP-413 Message Signing - Ed25519", () => {
 
     expect(signedMessage.accountId).toBe("alice.near")
     expect(signedMessage.publicKey).toBe(keyPair.publicKey.toString())
-    expect(signedMessage.signature).toMatch(/^[A-Za-z0-9+/]+=*$/) // Base64
+    expect(signedMessage.signature).toMatch(/^ed25519:[1-9A-HJ-NP-Za-km-z]+$/) // Base58 with prefix
     expect(signedMessage.signature.length).toBeGreaterThan(50)
   })
 
@@ -536,7 +536,7 @@ describe("NEP-413 Message Signing - Secp256k1", () => {
     expect(signedMessage.accountId).toBe("alice.near")
     expect(signedMessage.publicKey).toBe(keyPair.publicKey.toString())
     expect(signedMessage.publicKey).toMatch(/^secp256k1:/)
-    expect(signedMessage.signature).toMatch(/^[A-Za-z0-9+/]+=*$/) // Base64
+    expect(signedMessage.signature).toMatch(/^secp256k1:[1-9A-HJ-NP-Za-km-z]+$/) // Base58 with prefix
   })
 
   test("signNep413Message() should produce consistent signatures for same message", () => {
@@ -574,7 +574,7 @@ describe("NEP-413 Message Signing - Secp256k1", () => {
     expect(sig1.signature).not.toBe(sig2.signature)
   })
 
-  test("signNep413Message() should produce 65-byte signature (base64 encoded)", () => {
+  test("signNep413Message() should produce 65-byte signature (base58 encoded)", () => {
     const keyPair = Secp256k1KeyPair.fromRandom()
     const nonce = new Uint8Array(32)
 
@@ -584,7 +584,7 @@ describe("NEP-413 Message Signing - Secp256k1", () => {
       nonce,
     })
 
-    // Base64 encoding of 65 bytes should be ~88 characters
+    // Base58 encoding of 65 bytes should be ~90 characters (plus prefix)
     expect(signedMessage.signature.length).toBeGreaterThan(80)
   })
 


### PR DESCRIPTION
## Summary
- emit NEP-413 signatures as key-type-prefixed base58 for ed25519 and secp256k1
- prefer prefixed base58 in verification while keeping legacy base64/unprefixed fallback
- refresh tests/docs and add changeset

## Testing
- bun test tests/unit/nep413.test.ts tests/unit/key-utils.test.ts tests/unit/near-sign-message.test.ts