### PR TITLE
fix: add default export condition for Jest compatibility

### DIFF
--- a/.changeset/jest-exports-fix.md
+++ b/.changeset/jest-exports-fix.md
@@ -1,0 +1,5 @@
+---
+"near-kit": patch
+---
+
+Add default export condition for Jest compatibility

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "default": "./dist/index.js"
     },
     "./keys": {
       "import": "./dist/keys/index.js",


### PR DESCRIPTION
Adds `default` condition to the main export to allow Jest's resolver to find the module when transforming ESM to CJS.