### PR TITLE
feat(gas): update Gas.MAX to 1 PGas

### DIFF
--- a/.changeset/update-max-gas-1pgas.md
+++ b/.changeset/update-max-gas-1pgas.md
@@ -2,4 +2,4 @@
 "near-kit": minor
 ---
 
-Update Gas.MAX from 300 TGas to 1 PGas (1000 TGas) to match nearcore 2.11 protocol change
+Update Gas.MAX from "300 Tgas" to "1 Pgas" ("1000 Tgas") to match nearcore 2.11 protocol change

--- a/.changeset/update-max-gas-1pgas.md
+++ b/.changeset/update-max-gas-1pgas.md
@@ -1,0 +1,5 @@
+---
+"near-kit": minor
+---
+
+Update Gas.MAX from 300 TGas to 1 PGas (1000 TGas) to match nearcore 2.11 protocol change

--- a/packages/near-kit/src/utils/gas.ts
+++ b/packages/near-kit/src/utils/gas.ts
@@ -172,7 +172,8 @@ export function toGas(tgas: number): string {
  * exceeds Number.MAX_SAFE_INTEGER (~9007 TGas) or when it has more than
  * approximately 15–17 significant digits (for example, many fractional digits),
  * even if the whole part is within the safe integer range. For typical NEAR gas
- * limits (1 PGas max) without excessive decimal precision, this is not a concern.
+ * limits (~1000 Tgas, i.e. 1 PGas max) without excessive decimal precision, this
+ * is not a concern. This API still expects gas amounts to be expressed in Tgas units.
  * For applications requiring arbitrary precision, use formatGas(), which returns
  * a formatted string.
  *

--- a/packages/near-kit/src/utils/gas.ts
+++ b/packages/near-kit/src/utils/gas.ts
@@ -50,7 +50,7 @@ export const Gas = {
    * Common gas amounts.
    */
   DEFAULT: "30 Tgas" as `${number} Tgas`,
-  MAX: "300 Tgas" as `${number} Tgas`,
+  MAX: "1000 Tgas" as `${number} Tgas`,
 } as const
 
 /**
@@ -172,7 +172,7 @@ export function toGas(tgas: number): string {
  * exceeds Number.MAX_SAFE_INTEGER (~9007 TGas) or when it has more than
  * approximately 15–17 significant digits (for example, many fractional digits),
  * even if the whole part is within the safe integer range. For typical NEAR gas
- * limits (300 TGas max) without excessive decimal precision, this is not a concern.
+ * limits (1 PGas max) without excessive decimal precision, this is not a concern.
  * For applications requiring arbitrary precision, use formatGas(), which returns
  * a formatted string.
  *

--- a/packages/near-kit/tests/unit/gas.test.ts
+++ b/packages/near-kit/tests/unit/gas.test.ts
@@ -31,7 +31,7 @@ describe("Gas", () => {
     })
 
     test("MAX", () => {
-      expect(Gas.MAX).toBe("300 Tgas")
+      expect(Gas.MAX).toBe("1000 Tgas")
     })
   })
 })
@@ -114,7 +114,7 @@ describe("parseGas", () => {
 
     test("parses Gas.MAX", () => {
       const result = parseGas(Gas.MAX)
-      expect(result).toBe("300000000000000")
+      expect(result).toBe("1000000000000000")
     })
   })
 
@@ -326,10 +326,10 @@ describe("precision tests", () => {
   })
 
   test("formatGas handles large gas values without precision loss", () => {
-    // 300 Tgas (max gas) = 300000000000000 raw gas
-    const maxGas = "300000000000000"
+    // 1000 Tgas / 1 PGas (max gas) = 1000000000000000 raw gas
+    const maxGas = "1000000000000000"
     const result = formatGas(maxGas)
-    expect(result).toBe("300.00 Tgas")
+    expect(result).toBe("1000.00 Tgas")
   })
 
   test("formatGas handles values close to Number.MAX_SAFE_INTEGER", () => {

--- a/packages/near-kit/tests/unit/gas.test.ts
+++ b/packages/near-kit/tests/unit/gas.test.ts
@@ -326,7 +326,7 @@ describe("precision tests", () => {
   })
 
   test("formatGas handles large gas values without precision loss", () => {
-    // 1000 Tgas / 1 PGas (max gas) = 1000000000000000 raw gas
+    // 1000 Tgas (max gas) = 1000000000000000 raw gas
     const maxGas = "1000000000000000"
     const result = formatGas(maxGas)
     expect(result).toBe("1000.00 Tgas")


### PR DESCRIPTION
## Summary

- Update `Gas.MAX` from 300 TGas to 1 PGas (1000 TGas) to match nearcore 2.11
- Update related tests and documentation

Ref: near/devex#4