### PR TITLE
docs: remove Wallet Selector, rename HOT Connect to NEAR Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A simple, intuitive TypeScript library for interacting with NEAR Protocol. Desig
 - **Type safety everywhere** - Full TypeScript support with IDE autocomplete
 - **Progressive complexity** - Basic API for simple needs, advanced features when required
 - **Powerful transaction builder** - Fluent, human-readable API for transactions
-- **Wallet-ready** - Full support for [HOT Connector](https://github.com/azbang/hot-connector) and [NEAR Wallet Selector](https://github.com/near/wallet-selector), drop-in integration
+- **Wallet-ready** - Full support for [NEAR Connect](https://github.com/azbang/near-connect), drop-in integration
 
 ## Installation
 
@@ -100,11 +100,14 @@ const near = new Near({
 In the browser, connect to user wallets. The same `near.call()`, `near.send()`, and `near.transaction()` methods work seamlessly:
 
 ```typescript
-import { fromWalletSelector } from "near-kit"
+import { Near, fromHotConnect } from "near-kit"
+import { NearConnector } from "@hot-labs/near-connect"
+
+const connector = new NearConnector({ network: "testnet" })
 
 const near = new Near({
   network: "testnet",
-  wallet: fromWalletSelector(walletInstance),
+  wallet: fromHotConnect(connector),
 })
 
 // Same API as backend
@@ -281,37 +284,7 @@ const near = new Near({
 
 ## Wallet Integration
 
-near-kit integrates with Wallet Selector and HOT Connector through a signer abstraction. Wallet adapters are converted to signers via `fromWalletSelector()` and `fromHotConnect()` shims, allowing the same API to work across backend and frontend without separate client implementations.
-
-### NEAR Wallet Selector
-
-```typescript
-import { Near, fromWalletSelector } from "near-kit"
-import { setupWalletSelector } from "@near-wallet-selector/core"
-import { setupMyNearWallet } from "@near-wallet-selector/my-near-wallet"
-import { setupHereWallet } from "@near-wallet-selector/here-wallet"
-
-// Setup wallet selector
-const selector = await setupWalletSelector({
-  network: "testnet",
-  modules: [setupMyNearWallet(), setupHereWallet()],
-})
-
-// Get wallet instance (after user connects)
-const wallet = await selector.wallet()
-
-// Use with near-kit
-const near = new Near({
-  network: "testnet",
-  wallet: fromWalletSelector(wallet),
-})
-
-// All operations now use the wallet for signing
-await near.call("contract.near", "method", { arg: "value" })
-await near.send("bob.near", "10 NEAR")
-```
-
-### HOT Connector
+near-kit integrates with [NEAR Connect](https://github.com/azbang/near-connect) through a signer abstraction. The wallet adapter is converted to a signer via `fromHotConnect()`, allowing the same API to work across backend and frontend without separate client implementations.
 
 ```typescript
 import { Near, fromHotConnect } from "near-kit"
@@ -327,8 +300,9 @@ connector.on("wallet:signIn", async () => {
     wallet: fromHotConnect(connector),
   })
 
-  // Use near-kit with the connected wallet
+  // All operations now use the wallet for signing
   await near.call("contract.near", "method", { arg: "value" })
+  await near.send("bob.near", "10 NEAR")
 })
 
 // Trigger wallet connection

--- a/docs/dapp-workflow/frontend-integration.mdx
+++ b/docs/dapp-workflow/frontend-integration.mdx
@@ -10,7 +10,7 @@ title: "Frontend Integration"
 
 ## 🚀 Live Demo
 
-See `near-kit` running in a real React application using both Wallet Selector and HOT Connector.
+See `near-kit` running in a real React application using NEAR Connect.
 
 - **Live App:** [guestbook.near.tools](https://guestbook.near.tools/)
 - **Source Code:** [github.com/r-near/near-kit-guestbook-demo](https://github.com/r-near/near-kit-guestbook-demo)
@@ -24,53 +24,15 @@ You initialize the `Near` instance with a `wallet` object instead of a private k
 ```typescript
 const near = new Near({
   network: "testnet",
-  wallet: fromWalletSelector(wallet), // <--- The Adapter
+  wallet: fromHotConnect(connector), // <--- The Adapter
 })
 ```
 
 Once initialized, you use `near` exactly as you would in a backend script. When you call `.send()`, the library automatically triggers the wallet's popup for the user to approve the transaction.
 
-## 1. NEAR Wallet Selector
+## NEAR Connect
 
-[`@near-wallet-selector`](https://github.com/near/wallet-selector) is a popular library for connecting to the NEAR ecosystem. It supports MyNearWallet, Meteor, Sender, Here, and many others.
-
-### Setup
-
-```typescript
-import { setupWalletSelector } from "@near-wallet-selector/core"
-import { setupModal } from "@near-wallet-selector/modal-ui"
-import { Near, fromWalletSelector } from "near-kit"
-
-// 1. Initialize Wallet Selector (Standard Setup)
-const selector = await setupWalletSelector({
-  network: "testnet",
-  modules: [
-    /* ... wallet modules ... */
-  ],
-})
-
-const modal = setupModal(selector, { contractId: "guestbook.near" })
-
-// 2. Connect
-if (!selector.isSignedIn()) {
-  modal.show()
-}
-
-// 3. Create the Near Instance
-const wallet = await selector.wallet()
-
-const near = new Near({
-  network: "testnet",
-  wallet: fromWalletSelector(wallet),
-})
-
-// 4. Transact
-await near.send("bob.near", "1 NEAR")
-```
-
-## 2. HOT Connector
-
-[HOT Connector](https://github.com/azbang/hot-connector) is the new standard, and intended to replace NEAR Wallet Selector.
+[NEAR Connect](https://github.com/azbang/near-connect) is the standard wallet connection library for the NEAR ecosystem.
 
 ### Setup
 
@@ -89,7 +51,7 @@ connector.on("wallet:signIn", async (data) => {
     wallet: fromHotConnect(connector),
   })
 
-  console.log("Connected via HOT!")
+  console.log("Connected!")
 })
 
 // Trigger connection
@@ -109,7 +71,8 @@ Here is a simplified pattern from the [Guestbook Demo](https://github.com/r-near
 ```jsx
 // WalletProvider.tsx
 import { createContext, useContext, useEffect, useState } from "react"
-import { Near, fromWalletSelector } from "near-kit"
+import { Near, fromHotConnect } from "near-kit"
+import { NearConnector } from "@hot-labs/near-connect"
 
 const WalletContext = createContext<{ near: Near | null }>(null)
 
@@ -117,17 +80,18 @@ export const WalletProvider = ({ children }) => {
   const [near, setNear] = useState<Near | null>(null)
 
   useEffect(() => {
-    // ... setup selector ...
-    const wallet = await selector.wallet()
+    const connector = new NearConnector({ network: "testnet" })
 
-    if (wallet) {
+    connector.on("wallet:signIn", async () => {
       setNear(
         new Near({
           network: "testnet",
-          wallet: fromWalletSelector(wallet),
+          wallet: fromHotConnect(connector),
         })
       )
-    }
+    })
+
+    connector.connect()
   }, [])
 
   return (

--- a/docs/dapp-workflow/universal-pattern.mdx
+++ b/docs/dapp-workflow/universal-pattern.mdx
@@ -88,15 +88,17 @@ Now, let's see how to initialize the `Near` object for different environments.
     In the browser, you don't have private keys. You have a Wallet Adapter.
     
     ```typescript
-    import { Near, fromWalletSelector } from "near-kit"
+    import { Near, fromHotConnect } from "near-kit"
+    import { NearConnector } from "@hot-labs/near-connect"
     import { buyItem } from "./features/buy-item"
 
-    // ... setup wallet selector ...
-    const wallet = await selector.wallet()
+    // ... setup NEAR Connect ...
+    const connector = new NearConnector({ network: "testnet" })
+    const wallet = await connector.wallet()
 
     const near = new Near({
       network: "testnet",
-      wallet: fromWalletSelector(wallet), // Adapter handles signing
+      wallet: fromHotConnect(connector), // Adapter handles signing
     })
 
     const userAccount = (await wallet.getAccounts())[0].accountId

--- a/docs/react/provider.mdx
+++ b/docs/react/provider.mdx
@@ -182,31 +182,26 @@ For dApps where users connect their own wallets, create the Near instance dynami
 "use client"
 
 import { useState, useEffect } from "react"
-import { Near, fromWalletSelector } from "near-kit"
+import { Near, fromHotConnect } from "near-kit"
 import { NearProvider } from "@near-kit/react"
-import { setupWalletSelector } from "@near-wallet-selector/core"
+import { NearConnector } from "@hot-labs/near-connect"
 
 export function WalletProvider({ children }: { children: React.ReactNode }) {
   const [near, setNear] = useState<Near | null>(null)
 
   useEffect(() => {
-    async function init() {
-      const selector = await setupWalletSelector({
-        network: "mainnet",
-        modules: [/* ... */],
-      })
+    const connector = new NearConnector({ network: "mainnet" })
 
-      if (selector.isSignedIn()) {
-        const wallet = await selector.wallet()
-        setNear(
-          new Near({
-            network: "mainnet",
-            wallet: fromWalletSelector(wallet),
-          })
-        )
-      }
-    }
-    init()
+    connector.on("wallet:signIn", async () => {
+      setNear(
+        new Near({
+          network: "mainnet",
+          wallet: fromHotConnect(connector),
+        })
+      )
+    })
+
+    connector.connect()
   }, [])
 
   // Show loading or connect button when not connected

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -67,7 +67,7 @@ Controls which NEAR network to connect to.
   A wrapper around a browser wallet.
   
   ```typescript
-  wallet: fromWalletSelector(wallet)
+  wallet: fromHotConnect(connector)
   ```
 </ResponseField>
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@ bun run examples/quickstart.ts
 ```
 
 ### [`wallet-browser.ts`](./wallet-browser.ts)
-Connect to user wallets in the browser with HOT Connect or Wallet Selector.
+Connect to user wallets in the browser with NEAR Connect.
 
 ### [`meta-transactions.ts`](./meta-transactions.ts)
 Gasless transactions (NEP-366): user signs, relayer pays.

--- a/examples/universal-code.ts
+++ b/examples/universal-code.ts
@@ -7,7 +7,6 @@
 
 import {
   fromHotConnect,
-  fromWalletSelector,
   Near,
   type PrivateKey,
   type WalletConnection,
@@ -15,9 +14,7 @@ import {
 
 // External wallet types
 // biome-ignore lint/suspicious/noExplicitAny: External library type
-type HotConnector = { wallet(): Promise<any> }
-// biome-ignore lint/suspicious/noExplicitAny: External library type
-type WalletSelectorWallet = any
+type NearConnectorType = { wallet(): Promise<any> }
 
 // ============================================================================
 // Business Logic - Works in ANY environment
@@ -61,33 +58,16 @@ async function serverExample() {
 }
 
 // ============================================================================
-// Environment 2: Browser with HOT Connect
+// Environment 2: Browser with NEAR Connect
 // ============================================================================
 
-async function browserHotConnect(connector: HotConnector) {
+async function browserNearConnect(connector: NearConnectorType) {
   const near = new Near({
     network: "mainnet",
     wallet: fromHotConnect(connector),
   })
 
   const wallet = await connector.wallet()
-  const accounts = await wallet.getAccounts()
-  const signerId = accounts[0].accountId
-
-  await addGuestbookMessage(near, signerId, "Hello from browser")
-  await batchTransfer(near, signerId)
-}
-
-// ============================================================================
-// Environment 3: Browser with Wallet Selector
-// ============================================================================
-
-async function browserWalletSelector(wallet: WalletSelectorWallet) {
-  const near = new Near({
-    network: "testnet",
-    wallet: fromWalletSelector(wallet),
-  })
-
   const accounts = await wallet.getAccounts()
   const signerId = accounts[0].accountId
 
@@ -155,7 +135,6 @@ export {
   addGuestbookMessage,
   batchTransfer,
   serverExample,
-  browserHotConnect,
-  browserWalletSelector,
+  browserNearConnect,
   universalExample,
 }

--- a/examples/wallet-browser.ts
+++ b/examples/wallet-browser.ts
@@ -1,39 +1,28 @@
 /**
  * Browser Wallet Integration
  *
- * Connect to user wallets using HOT Connect or Wallet Selector.
+ * Connect to user wallets using NEAR Connect.
  * Same near-kit API works in browser and server.
  *
  * Setup:
  *   npm install @hot-labs/near-connect
- *   OR
- *   npm install @near-wallet-selector/core @near-wallet-selector/modal-ui
  */
 
-import { fromHotConnect, fromWalletSelector, Near } from "../src/index.js"
+import { fromHotConnect, Near } from "../src/index.js"
 
 // Type definitions for external libraries
 // biome-ignore lint/suspicious/noExplicitAny: External library type
 declare const NearConnector: any
-// biome-ignore lint/suspicious/noExplicitAny: External library type
-declare const setupWalletSelector: any
-// biome-ignore lint/suspicious/noExplicitAny: External library type
-declare const setupModal: any
-// biome-ignore lint/suspicious/noExplicitAny: External library type
-declare const setupMyNearWallet: any
 
 type WalletSignInEvent = {
   accounts: Array<{ accountId: string; publicKey: string }>
 }
-type WalletSelectorState = {
-  accounts: Array<{ accountId: string; publicKey: string }>
-}
 
 // ============================================================================
-// HOT Connect (Recommended)
+// NEAR Connect
 // ============================================================================
 
-async function hotConnectExample() {
+async function nearConnectExample() {
   // biome-ignore lint/suspicious/noExplicitAny: External library type
   const connector = new (NearConnector as any)({
     network: "mainnet",
@@ -79,49 +68,7 @@ async function hotConnectExample() {
   })
 
   // In UI: <button onClick={() => connector.show()}>Connect</button>
-  console.log("HOT Connect ready")
-}
-
-// ============================================================================
-// Wallet Selector (Alternative)
-// ============================================================================
-
-async function walletSelectorExample() {
-  const selector = await setupWalletSelector({
-    network: "testnet",
-    modules: [setupMyNearWallet()],
-  })
-
-  const modal = setupModal(selector, {
-    contractId: "guestbook.near-examples.testnet",
-  })
-
-  modal.show()
-
-  const unsubscribe = selector.store.observable.subscribe(
-    async (state: WalletSelectorState) => {
-      if (state.accounts.length > 0) {
-        const accountId = state.accounts[0]?.accountId
-        if (!accountId) return
-        const wallet = await selector.wallet()
-
-        const near = new Near({
-          network: "testnet",
-          wallet: fromWalletSelector(wallet),
-        })
-
-        await near.call(
-          "guestbook.near-examples.testnet",
-          "add_message",
-          { text: "Hello from Wallet Selector" },
-          { signerId: accountId, gas: "30 Tgas" },
-        )
-
-        console.log("Transaction sent")
-        unsubscribe()
-      }
-    },
-  )
+  console.log("NEAR Connect ready")
 }
 
 // ============================================================================
@@ -130,12 +77,11 @@ async function walletSelectorExample() {
 
 async function main() {
   console.log("Browser Wallet Integration\n")
-  console.log("HOT Connect: Modern, iframe-isolated, WalletConnect v2")
-  console.log("Wallet Selector: Traditional, wider wallet support")
+  console.log("NEAR Connect: Modern, iframe-isolated, WalletConnect v2")
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
   main()
 }
 
-export { hotConnectExample, walletSelectorExample }
+export { nearConnectExample }

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -321,40 +321,18 @@ const { data: balance } = useSWR(
 
 ## Wallet Integration
 
-### With Wallet Selector
+### With NEAR Connect
 
 ```tsx
-import { setupWalletSelector } from "@near-wallet-selector/core"
-import { fromWalletSelector } from "near-kit"
-
-const selector = await setupWalletSelector({
-  network: "testnet",
-  modules: [/* your wallet modules */],
-})
-const wallet = await selector.wallet()
-
-<NearProvider
-  config={{
-    network: "testnet",
-    wallet: fromWalletSelector(wallet),
-  }}
->
-  <App />
-</NearProvider>
-```
-
-### With HOT Connect
-
-```tsx
-import { setupNearConnect } from "@hot-labs/near-connect"
+import { NearConnector } from "@hot-labs/near-connect"
 import { fromHotConnect } from "near-kit"
 
-const connect = await setupNearConnect({ network: "testnet" })
+const connector = new NearConnector({ network: "testnet" })
 
 <NearProvider
   config={{
     network: "testnet",
-    wallet: fromHotConnect(connect),
+    wallet: fromHotConnect(connector),
   }}
 >
   <App />


### PR DESCRIPTION
## Summary

- Remove all NEAR Wallet Selector references from docs and examples (deprecated)
- Rename HOT Connect / HOT Connector to NEAR Connect throughout
- Update code examples to use `fromHotConnect(connector)` as the primary wallet integration path

## Test plan

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes