### PR TITLE
refactor(wallets): rename fromHotConnect to fromNearConnect, deprecate Wallet Selector

### DIFF
--- a/.changeset/rename-hot-connect-to-near-connect.md
+++ b/.changeset/rename-hot-connect-to-near-connect.md
@@ -1,0 +1,5 @@
+---
+"near-kit": minor
+---
+
+Rename `fromHotConnect` to `fromNearConnect` and deprecate old name. Deprecate `fromWalletSelector` (NEAR Wallet Selector is deprecated). Internal `HotConnect*` types renamed to `NearConnect*` with deprecated aliases.

--- a/packages/near-kit/src/core/types.ts
+++ b/packages/near-kit/src/core/types.ts
@@ -454,7 +454,7 @@ export interface SignDelegateActionsResult {
 
 /**
  * Wallet connection interface
- * Compatible with @hot-labs/near-connect (NEAR Connect)
+ * Compatible with NEAR wallet adapters including @hot-labs/near-connect (NEAR Connect)
  */
 export interface WalletConnection {
   /**

--- a/packages/near-kit/src/core/types.ts
+++ b/packages/near-kit/src/core/types.ts
@@ -454,7 +454,7 @@ export interface SignDelegateActionsResult {
 
 /**
  * Wallet connection interface
- * Compatible with both @near-wallet-selector and @hot-labs/near-connect
+ * Compatible with @hot-labs/near-connect (NEAR Connect)
  */
 export interface WalletConnection {
   /**

--- a/packages/near-kit/src/index.ts
+++ b/packages/near-kit/src/index.ts
@@ -111,4 +111,8 @@ export {
   verifyNep413Signature,
 } from "./utils/index.js"
 // Wallet adapters
-export { fromHotConnect, fromWalletSelector } from "./wallets/index.js"
+export {
+  fromHotConnect,
+  fromNearConnect,
+  fromWalletSelector,
+} from "./wallets/index.js"

--- a/packages/near-kit/src/wallets/adapters.ts
+++ b/packages/near-kit/src/wallets/adapters.ts
@@ -2,8 +2,8 @@
  * Wallet adapters for NEAR wallet integrations.
  *
  * Provides adapter functions to integrate with popular NEAR wallets:
- * - `@near-wallet-selector/core`
- * - `@hot-labs/near-connect`
+ * - `@hot-labs/near-connect` (NEAR Connect)
+ * - `@near-wallet-selector/core` (deprecated)
  *
  * These adapters use duck typing / structural compatibility to work with
  * wallet interfaces. While the actual wallet packages use `@near-js` types
@@ -22,12 +22,12 @@ import type {
   WalletConnection,
 } from "../core/types.js"
 import type {
-  HotConnectAction,
-  HotConnectAddKeyPermission,
-  HotConnectConnector,
+  NearConnectAction,
+  NearConnectAddKeyPermission,
+  NearConnectConnector,
 } from "./types.js"
 
-// Wallet interface types based on @near-wallet-selector/core v10.x
+// Wallet interface types based on @near-wallet-selector/core v10.x (deprecated).
 // These are duck-typed to match the actual wallet interface structure.
 // Note: Some wallet-selector implementations type signAndSendTransaction
 // as returning `void | FinalExecutionOutcome`. We normalize this to always
@@ -50,10 +50,10 @@ type WalletSelectorWallet = {
 }
 
 /**
- * Convert a near-kit Action to HOT Connect's action format.
+ * Convert a near-kit Action to NEAR Connect's action format.
  * @internal
  */
-function convertActionToHotConnect(action: Action): HotConnectAction {
+function convertActionToNearConnect(action: Action): NearConnectAction {
   const a = action as Record<string, unknown>
 
   if ("functionCall" in a && a["functionCall"]) {
@@ -100,7 +100,7 @@ function convertActionToHotConnect(action: Action): HotConnectAction {
       type: "Stake",
       params: {
         stake: s.stake.toString(),
-        // HOT Connect expects a base58 string; we forward whatever representation
+        // NEAR Connect expects a base58 string; we forward whatever representation
         // we have and rely on upstream tooling when stake is used with wallets.
         publicKey: String(s.publicKey),
       },
@@ -118,7 +118,7 @@ function convertActionToHotConnect(action: Action): HotConnectAction {
         publicKey: String(ak.publicKey),
         accessKey: {
           nonce: Number(ak.accessKey.nonce),
-          permission: ak.accessKey.permission as HotConnectAddKeyPermission,
+          permission: ak.accessKey.permission as NearConnectAddKeyPermission,
         },
       },
     }
@@ -169,6 +169,9 @@ function convertActionToHotConnect(action: Action): HotConnectAction {
  * Adapter for @near-wallet-selector/core
  *
  * Converts a wallet-selector Wallet instance to the WalletConnection interface.
+ *
+ * @deprecated NEAR Wallet Selector is deprecated. Use {@link fromNearConnect} with
+ * `@hot-labs/near-connect` (NEAR Connect) instead.
  *
  * @param wallet - Wallet instance from wallet-selector
  * @returns WalletConnection interface compatible with near-kit
@@ -242,18 +245,18 @@ export function fromWalletSelector(
 }
 
 /**
- * Adapter for @hot-labs/near-connect (HOT Connect)
+ * Adapter for @hot-labs/near-connect (NEAR Connect)
  *
- * Converts a HOT Connect NearConnector instance to the WalletConnection interface.
+ * Converts a NEAR Connect NearConnector instance to the WalletConnection interface.
  *
- * @param connector - NearConnector instance from HOT Connect
+ * @param connector - NearConnector instance from NEAR Connect
  * @returns WalletConnection interface compatible with near-kit
  *
  * @example
  * ```typescript
  * import { Near } from 'near-kit'
  * import { NearConnector } from '@hot-labs/near-connect'
- * import { fromHotConnect } from 'near-kit/wallets'
+ * import { fromNearConnect } from 'near-kit/wallets'
  *
  * const connector = new NearConnector({ network: 'mainnet' })
  *
@@ -261,7 +264,7 @@ export function fromWalletSelector(
  * connector.on('wallet:signIn', async () => {
  *   const near = new Near({
  *     network: 'mainnet',
- *     wallet: fromHotConnect(connector)
+ *     wallet: fromNearConnect(connector)
  *   })
  *
  *   // Use near-kit with the connected wallet
@@ -269,13 +272,13 @@ export function fromWalletSelector(
  * })
  * ```
  */
-export function fromHotConnect(
-  connector: HotConnectConnector,
+export function fromNearConnect(
+  connector: NearConnectConnector,
 ): WalletConnection {
   // Validate that we have a proper connector
   if (!connector || typeof connector.wallet !== "function") {
     throw new Error(
-      "Invalid HOT Connect instance. Make sure @hot-labs/near-connect is installed and you're passing a NearConnector instance.",
+      "Invalid NEAR Connect instance. Make sure @hot-labs/near-connect is installed and you're passing a NearConnector instance.",
     )
   }
 
@@ -292,12 +295,12 @@ export function fromHotConnect(
 
     async signAndSendTransaction(params): Promise<FinalExecutionOutcome> {
       const wallet = await connector.wallet()
-      const hotConnectorActions = params.actions.map(convertActionToHotConnect)
+      const nearConnectActions = params.actions.map(convertActionToNearConnect)
 
       const result = await wallet.signAndSendTransaction({
         ...(params.signerId !== undefined && { signerId: params.signerId }),
         receiverId: params.receiverId,
-        actions: hotConnectorActions,
+        actions: nearConnectActions,
       })
 
       return result as FinalExecutionOutcome
@@ -329,9 +332,9 @@ export function fromHotConnect(
         )
       }
 
-      // Convert each delegate action's near-kit Actions to HOT Connect format
+      // Convert each delegate action's near-kit Actions to NEAR Connect format
       const hotDelegateActions = params.delegateActions.map((da) => ({
-        actions: da.actions.map(convertActionToHotConnect),
+        actions: da.actions.map(convertActionToNearConnect),
         receiverId: da.receiverId,
       }))
 
@@ -365,3 +368,8 @@ export function fromHotConnect(
     },
   }
 }
+
+/**
+ * @deprecated Renamed to {@link fromNearConnect}. This alias will be removed in a future major version.
+ */
+export const fromHotConnect = fromNearConnect

--- a/packages/near-kit/src/wallets/adapters.ts
+++ b/packages/near-kit/src/wallets/adapters.ts
@@ -333,14 +333,14 @@ export function fromNearConnect(
       }
 
       // Convert each delegate action's near-kit Actions to NEAR Connect format
-      const hotDelegateActions = params.delegateActions.map((da) => ({
+      const nearConnectDelegateActions = params.delegateActions.map((da) => ({
         actions: da.actions.map(convertActionToNearConnect),
         receiverId: da.receiverId,
       }))
 
       const response = await wallet.signDelegateActions({
         ...(params.signerId !== undefined && { signerId: params.signerId }),
-        delegateActions: hotDelegateActions,
+        delegateActions: nearConnectDelegateActions,
       })
 
       // Bridge response shape: near-connect returns @near-js/transactions

--- a/packages/near-kit/src/wallets/index.ts
+++ b/packages/near-kit/src/wallets/index.ts
@@ -2,9 +2,9 @@
  * Wallet integration adapters for NEAR.
  *
  * @remarks
- * Re-exports the {@link WalletConnection} interface and concrete adapters
- * {@link fromNearConnect} and {@link fromWalletSelector} for integrating with
- * NEAR wallet libraries.
+ * Re-exports the {@link WalletConnection} interface and wallet adapters:
+ * {@link fromNearConnect} (recommended), deprecated {@link fromHotConnect} alias,
+ * and deprecated {@link fromWalletSelector}.
  */
 export type { WalletConnection } from "../core/types.js"
 export {

--- a/packages/near-kit/src/wallets/index.ts
+++ b/packages/near-kit/src/wallets/index.ts
@@ -3,8 +3,12 @@
  *
  * @remarks
  * Re-exports the {@link WalletConnection} interface and concrete adapters
- * {@link fromWalletSelector} and {@link fromHotConnect} for integrating with
- * common NEAR wallet libraries.
+ * {@link fromNearConnect} and {@link fromWalletSelector} for integrating with
+ * NEAR wallet libraries.
  */
 export type { WalletConnection } from "../core/types.js"
-export { fromHotConnect, fromWalletSelector } from "./adapters.js"
+export {
+  fromHotConnect,
+  fromNearConnect,
+  fromWalletSelector,
+} from "./adapters.js"

--- a/packages/near-kit/src/wallets/types.ts
+++ b/packages/near-kit/src/wallets/types.ts
@@ -2,7 +2,7 @@
  * Internal wallet type helpers for near-kit.
  *
  * Defines lightweight structural types for external wallet libraries
- * (e.g. HOT Connect) without taking a hard dependency on their packages.
+ * (e.g. NEAR Connect) without taking a hard dependency on their packages.
  *
  * @internal
  */
@@ -14,22 +14,22 @@ import type {
 } from "../core/types.js"
 
 /**
- * HOT Connect action types, mirroring `@hot-labs/near-connect`'s
+ * NEAR Connect action types, mirroring `@hot-labs/near-connect`'s
  * `types/transactions.ts` definitions.
  */
 
-export type HotConnectCreateAccountAction = {
+export type NearConnectCreateAccountAction = {
   type: "CreateAccount"
 }
 
-export type HotConnectDeployContractAction = {
+export type NearConnectDeployContractAction = {
   type: "DeployContract"
   params: {
     code: Uint8Array
   }
 }
 
-export type HotConnectFunctionCallAction = {
+export type NearConnectFunctionCallAction = {
   type: "FunctionCall"
   params: {
     methodName: string
@@ -39,14 +39,14 @@ export type HotConnectFunctionCallAction = {
   }
 }
 
-export type HotConnectTransferAction = {
+export type NearConnectTransferAction = {
   type: "Transfer"
   params: {
     deposit: string
   }
 }
 
-export type HotConnectStakeAction = {
+export type NearConnectStakeAction = {
   type: "Stake"
   params: {
     stake: string
@@ -54,7 +54,7 @@ export type HotConnectStakeAction = {
   }
 }
 
-export type HotConnectAddKeyPermission =
+export type NearConnectAddKeyPermission =
   | "FullAccess"
   | {
       receiverId: string
@@ -62,68 +62,68 @@ export type HotConnectAddKeyPermission =
       methodNames?: string[]
     }
 
-export type HotConnectAddKeyAction = {
+export type NearConnectAddKeyAction = {
   type: "AddKey"
   params: {
     publicKey: string
     accessKey: {
       nonce?: number
-      permission: HotConnectAddKeyPermission
+      permission: NearConnectAddKeyPermission
     }
   }
 }
 
-export type HotConnectDeleteKeyAction = {
+export type NearConnectDeleteKeyAction = {
   type: "DeleteKey"
   params: {
     publicKey: string
   }
 }
 
-export type HotConnectDeleteAccountAction = {
+export type NearConnectDeleteAccountAction = {
   type: "DeleteAccount"
   params: {
     beneficiaryId: string
   }
 }
 
-export type HotConnectAction =
-  | HotConnectCreateAccountAction
-  | HotConnectDeployContractAction
-  | HotConnectFunctionCallAction
-  | HotConnectTransferAction
-  | HotConnectStakeAction
-  | HotConnectAddKeyAction
-  | HotConnectDeleteKeyAction
-  | HotConnectDeleteAccountAction
+export type NearConnectAction =
+  | NearConnectCreateAccountAction
+  | NearConnectDeployContractAction
+  | NearConnectFunctionCallAction
+  | NearConnectTransferAction
+  | NearConnectStakeAction
+  | NearConnectAddKeyAction
+  | NearConnectDeleteKeyAction
+  | NearConnectDeleteAccountAction
 
 /**
- * HOT Connect wallet + connector interfaces (structural).
+ * NEAR Connect wallet + connector interfaces (structural).
  */
 
 /**
- * HOT Connect's params for signDelegateActions (v0.9.0+).
- * Uses HotConnectAction[] instead of our Action[].
+ * NEAR Connect's params for signDelegateActions (v0.9.0+).
+ * Uses NearConnectAction[] instead of our Action[].
  * @internal
  */
-export type HotConnectSignDelegateActionsParams = {
+export type NearConnectSignDelegateActionsParams = {
   network?: string
   signerId?: string
   delegateActions: Array<{
-    actions: HotConnectAction[]
+    actions: NearConnectAction[]
     receiverId: string
   }>
 }
 
 /**
- * HOT Connect's response for signDelegateActions (v0.9.0+).
+ * NEAR Connect's response for signDelegateActions (v0.9.0+).
  * @internal
  */
-export type HotConnectSignDelegateActionsResponse = {
+export type NearConnectSignDelegateActionsResponse = {
   signedDelegateActions: SignDelegateActionsResult["signedDelegateActions"]
 }
 
-export type HotConnectWallet = {
+export type NearConnectWallet = {
   manifest?: {
     features?: {
       signDelegateAction?: boolean
@@ -138,7 +138,7 @@ export type HotConnectWallet = {
   signAndSendTransaction(params: {
     signerId?: string
     receiverId: string
-    actions: HotConnectAction[]
+    actions: NearConnectAction[]
     network?: string
   }): Promise<FinalExecutionOutcome>
   signMessage(params: {
@@ -148,10 +148,17 @@ export type HotConnectWallet = {
     network?: string
   }): Promise<SignedMessage>
   signDelegateActions?(
-    params: HotConnectSignDelegateActionsParams,
-  ): Promise<HotConnectSignDelegateActionsResponse>
+    params: NearConnectSignDelegateActionsParams,
+  ): Promise<NearConnectSignDelegateActionsResponse>
 }
 
-export type HotConnectConnector = {
-  wallet(): Promise<HotConnectWallet>
+export type NearConnectConnector = {
+  wallet(): Promise<NearConnectWallet>
 }
+
+/** @deprecated Use {@link NearConnectAction} instead */
+export type HotConnectAction = NearConnectAction
+/** @deprecated Use {@link NearConnectAddKeyPermission} instead */
+export type HotConnectAddKeyPermission = NearConnectAddKeyPermission
+/** @deprecated Use {@link NearConnectConnector} instead */
+export type HotConnectConnector = NearConnectConnector

--- a/packages/near-kit/src/wallets/types.ts
+++ b/packages/near-kit/src/wallets/types.ts
@@ -156,9 +156,33 @@ export type NearConnectConnector = {
   wallet(): Promise<NearConnectWallet>
 }
 
-/** @deprecated Use {@link NearConnectAction} instead */
-export type HotConnectAction = NearConnectAction
+/** @deprecated Use {@link NearConnectCreateAccountAction} instead */
+export type HotConnectCreateAccountAction = NearConnectCreateAccountAction
+/** @deprecated Use {@link NearConnectDeployContractAction} instead */
+export type HotConnectDeployContractAction = NearConnectDeployContractAction
+/** @deprecated Use {@link NearConnectFunctionCallAction} instead */
+export type HotConnectFunctionCallAction = NearConnectFunctionCallAction
+/** @deprecated Use {@link NearConnectTransferAction} instead */
+export type HotConnectTransferAction = NearConnectTransferAction
+/** @deprecated Use {@link NearConnectStakeAction} instead */
+export type HotConnectStakeAction = NearConnectStakeAction
 /** @deprecated Use {@link NearConnectAddKeyPermission} instead */
 export type HotConnectAddKeyPermission = NearConnectAddKeyPermission
+/** @deprecated Use {@link NearConnectAddKeyAction} instead */
+export type HotConnectAddKeyAction = NearConnectAddKeyAction
+/** @deprecated Use {@link NearConnectDeleteKeyAction} instead */
+export type HotConnectDeleteKeyAction = NearConnectDeleteKeyAction
+/** @deprecated Use {@link NearConnectDeleteAccountAction} instead */
+export type HotConnectDeleteAccountAction = NearConnectDeleteAccountAction
+/** @deprecated Use {@link NearConnectAction} instead */
+export type HotConnectAction = NearConnectAction
+/** @deprecated Use {@link NearConnectSignDelegateActionsParams} instead */
+export type HotConnectSignDelegateActionsParams =
+  NearConnectSignDelegateActionsParams
+/** @deprecated Use {@link NearConnectSignDelegateActionsResponse} instead */
+export type HotConnectSignDelegateActionsResponse =
+  NearConnectSignDelegateActionsResponse
+/** @deprecated Use {@link NearConnectWallet} instead */
+export type HotConnectWallet = NearConnectWallet
 /** @deprecated Use {@link NearConnectConnector} instead */
 export type HotConnectConnector = NearConnectConnector

--- a/packages/near-kit/tests/wallets/adapter-spying.test.ts
+++ b/packages/near-kit/tests/wallets/adapter-spying.test.ts
@@ -10,8 +10,8 @@
 
 import { describe, expect, it } from "vitest"
 import * as actions from "../../src/core/actions.js"
-import { fromHotConnect, fromWalletSelector } from "../../src/wallets/index.js"
-import { MockHotConnect, MockWalletSelector } from "./mock-wallets.js"
+import { fromNearConnect, fromWalletSelector } from "../../src/wallets/index.js"
+import { MockNearConnect, MockWalletSelector } from "./mock-wallets.js"
 
 describe("Wallet Adapter Data Flow Verification", () => {
   describe("fromWalletSelector - Parameter Passing", () => {
@@ -158,12 +158,12 @@ describe("Wallet Adapter Data Flow Verification", () => {
     })
   })
 
-  describe("fromHotConnect - Parameter Passing", () => {
-    it("should translate Actions for HOT Connect signAndSendTransaction", async () => {
-      const mockConnector = new MockHotConnect([
+  describe("fromNearConnect - Parameter Passing", () => {
+    it("should translate Actions for NEAR Connect signAndSendTransaction", async () => {
+      const mockConnector = new MockNearConnect([
         { accountId: "alice.near", publicKey: "ed25519:abc123" },
       ])
-      const adapter = fromHotConnect(mockConnector)
+      const adapter = fromNearConnect(mockConnector)
 
       // Create actions
       const transferAction = actions.transfer(
@@ -203,10 +203,10 @@ describe("Wallet Adapter Data Flow Verification", () => {
     })
 
     it("should pass Uint8Array nonce unchanged for signMessage", async () => {
-      const mockConnector = new MockHotConnect([
+      const mockConnector = new MockNearConnect([
         { accountId: "alice.near", publicKey: "ed25519:abc123" },
       ])
-      const adapter = fromHotConnect(mockConnector)
+      const adapter = fromNearConnect(mockConnector)
 
       // Create a Uint8Array nonce (what our API uses)
       const nonce = new Uint8Array([9, 8, 7, 6, 5, 4, 3, 2, 1])
@@ -228,7 +228,7 @@ describe("Wallet Adapter Data Flow Verification", () => {
       expect(msgCall).toBeDefined()
       if (!msgCall) return
 
-      // CRITICAL: HOT Connect uses Uint8Array, should NOT be converted to Buffer
+      // CRITICAL: NEAR Connect uses Uint8Array, should NOT be converted to Buffer
       const noncePassed = msgCall.params.nonce
       expect(noncePassed).toBeInstanceOf(Uint8Array)
       expect(noncePassed).toBe(nonce) // Should be the SAME object
@@ -240,10 +240,10 @@ describe("Wallet Adapter Data Flow Verification", () => {
     })
 
     it("should handle complex action types correctly", async () => {
-      const mockConnector = new MockHotConnect([
+      const mockConnector = new MockNearConnect([
         { accountId: "alice.near", publicKey: "ed25519:abc123" },
       ])
-      const adapter = fromHotConnect(mockConnector)
+      const adapter = fromNearConnect(mockConnector)
 
       // Create various action types
       const actionsToTest = [
@@ -447,15 +447,15 @@ describe("Wallet Adapter Data Flow Verification", () => {
       expect(accounts[0]).not.toHaveProperty("publicKey")
     })
 
-    it("should always include publicKey for HOT Connect accounts", async () => {
-      const mockConnector = new MockHotConnect([
+    it("should always include publicKey for NEAR Connect accounts", async () => {
+      const mockConnector = new MockNearConnect([
         { accountId: "test.near" }, // No publicKey provided
       ])
-      const adapter = fromHotConnect(mockConnector)
+      const adapter = fromNearConnect(mockConnector)
 
       const accounts = await adapter.getAccounts()
 
-      // HOT Connect REQUIRES publicKey, mock should add default
+      // NEAR Connect REQUIRES publicKey, mock should add default
       expect(accounts).toHaveLength(1)
       const account = accounts[0]
       expect(account).toHaveProperty("publicKey")
@@ -489,10 +489,10 @@ describe("Wallet Adapter Data Flow Verification", () => {
     })
 
     it("should not modify the nonce Uint8Array", async () => {
-      const mockConnector = new MockHotConnect([
+      const mockConnector = new MockNearConnect([
         { accountId: "test.near", publicKey: "ed25519:test" },
       ])
-      const adapter = fromHotConnect(mockConnector)
+      const adapter = fromNearConnect(mockConnector)
 
       const originalNonce = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
       const nonceCopy = new Uint8Array(originalNonce)

--- a/packages/near-kit/tests/wallets/adapters.test.ts
+++ b/packages/near-kit/tests/wallets/adapters.test.ts
@@ -4,9 +4,9 @@
 
 import { describe, expect, it } from "vitest"
 import * as actions from "../../src/core/actions.js"
-import { fromHotConnect, fromWalletSelector } from "../../src/wallets/index.js"
+import { fromNearConnect, fromWalletSelector } from "../../src/wallets/index.js"
 import {
-  MockHotConnect,
+  MockNearConnect,
   MockWalletSelector,
   MockWalletWithoutSignMessage,
 } from "./mock-wallets.js"
@@ -93,14 +93,14 @@ describe("Wallet Adapters", () => {
     })
   })
 
-  describe("fromHotConnect", () => {
-    it("should adapt HOT Connect getAccounts", async () => {
-      const mockConnector = new MockHotConnect([
+  describe("fromNearConnect", () => {
+    it("should adapt NEAR Connect getAccounts", async () => {
+      const mockConnector = new MockNearConnect([
         { accountId: "alice.near", publicKey: "ed25519:abc123" },
         { accountId: "bob.near", publicKey: "ed25519:def456" },
       ])
 
-      const adapter = fromHotConnect(mockConnector)
+      const adapter = fromNearConnect(mockConnector)
       const accounts = await adapter.getAccounts()
 
       expect(accounts).toEqual([
@@ -114,12 +114,12 @@ describe("Wallet Adapters", () => {
       expect(log.some((l) => l.method === "getAccounts")).toBe(true)
     })
 
-    it("should adapt HOT Connect signAndSendTransaction", async () => {
-      const mockConnector = new MockHotConnect([
+    it("should adapt NEAR Connect signAndSendTransaction", async () => {
+      const mockConnector = new MockNearConnect([
         { accountId: "alice.near", publicKey: "ed25519:abc123" },
       ])
 
-      const adapter = fromHotConnect(mockConnector)
+      const adapter = fromNearConnect(mockConnector)
 
       const transferAction = actions.transfer(
         BigInt("1000000000000000000000000"),
@@ -143,12 +143,12 @@ describe("Wallet Adapters", () => {
       expect(txCall?.params.receiverId).toBe("bob.near")
     })
 
-    it("should correctly parse JSON args in HOT Connect functionCall", async () => {
-      const mockConnector = new MockHotConnect([
+    it("should correctly parse JSON args in NEAR Connect functionCall", async () => {
+      const mockConnector = new MockNearConnect([
         { accountId: "alice.near", publicKey: "ed25519:abc123" },
       ])
 
-      const adapter = fromHotConnect(mockConnector)
+      const adapter = fromNearConnect(mockConnector)
 
       const args = { foo: "bar" }
       const argsBytes = new TextEncoder().encode(JSON.stringify(args))
@@ -177,12 +177,12 @@ describe("Wallet Adapters", () => {
       expect(hotAction.params.args).toEqual(args)
     })
 
-    it("should adapt HOT Connect signMessage", async () => {
-      const mockConnector = new MockHotConnect([
+    it("should adapt NEAR Connect signMessage", async () => {
+      const mockConnector = new MockNearConnect([
         { accountId: "alice.near", publicKey: "ed25519:abc123" },
       ])
 
-      const adapter = fromHotConnect(mockConnector)
+      const adapter = fromNearConnect(mockConnector)
 
       const result = await adapter.signMessage?.({
         message: "Hello, NEAR!",

--- a/packages/near-kit/tests/wallets/delegate-signing.test.ts
+++ b/packages/near-kit/tests/wallets/delegate-signing.test.ts
@@ -2,7 +2,7 @@
  * Tests for wallet-based delegate action signing (signDelegateActions)
  *
  * Covers:
- * - fromHotConnect adapter: action conversion, batch passthrough, response normalization
+ * - fromNearConnect adapter: action conversion, batch passthrough, response normalization
  * - TransactionBuilder.delegate() wallet routing: wraps single → batch, unwraps result
  * - Feature detection and error paths
  */
@@ -17,8 +17,8 @@ import type {
   WalletConnection,
 } from "../../src/core/types.js"
 import { InMemoryKeyStore } from "../../src/keys/in-memory-keystore.js"
-import { fromHotConnect } from "../../src/wallets/index.js"
-import { MockHotConnect } from "./mock-wallets.js"
+import { fromNearConnect } from "../../src/wallets/index.js"
+import { MockNearConnect } from "./mock-wallets.js"
 
 // Minimal mock RPC for TransactionBuilder (not used in wallet path)
 function mockRpc() {
@@ -32,13 +32,13 @@ function mockRpc() {
 }
 
 describe("Wallet Delegate Action Signing", () => {
-  describe("fromHotConnect - signDelegateActions", () => {
+  describe("fromNearConnect - signDelegateActions", () => {
     it("should convert actions and pass through to wallet", async () => {
-      const mockConnector = new MockHotConnect([
+      const mockConnector = new MockNearConnect([
         { accountId: "alice.near", publicKey: "ed25519:abc123" },
       ])
 
-      const adapter = fromHotConnect(mockConnector)
+      const adapter = fromNearConnect(mockConnector)
 
       const transferAction = actions.transfer(
         BigInt("1000000000000000000000000"),
@@ -61,7 +61,7 @@ describe("Wallet Delegate Action Signing", () => {
       )
       expect(result.signedDelegateActions[0]?.signedDelegate).toBeDefined()
 
-      // Verify actions were converted to HOT Connect format
+      // Verify actions were converted to NEAR Connect format
       const log = mockConnector.getCallLog()
       const delegateCall = log.find((l) => l.method === "signDelegateActions")
       expect(delegateCall).toBeDefined()
@@ -75,11 +75,11 @@ describe("Wallet Delegate Action Signing", () => {
     })
 
     it("should convert functionCall args to JSON objects", async () => {
-      const mockConnector = new MockHotConnect([
+      const mockConnector = new MockNearConnect([
         { accountId: "alice.near", publicKey: "ed25519:abc123" },
       ])
 
-      const adapter = fromHotConnect(mockConnector)
+      const adapter = fromNearConnect(mockConnector)
 
       const args = { message: "hello" }
       const argsBytes = new TextEncoder().encode(JSON.stringify(args))
@@ -115,11 +115,11 @@ describe("Wallet Delegate Action Signing", () => {
     })
 
     it("should handle multiple delegate actions in batch", async () => {
-      const mockConnector = new MockHotConnect([
+      const mockConnector = new MockNearConnect([
         { accountId: "alice.near", publicKey: "ed25519:abc123" },
       ])
 
-      const adapter = fromHotConnect(mockConnector)
+      const adapter = fromNearConnect(mockConnector)
 
       // biome-ignore lint/style/noNonNullAssertion: adapter always provides signDelegateActions
       const result = await adapter.signDelegateActions!({
@@ -147,11 +147,11 @@ describe("Wallet Delegate Action Signing", () => {
     })
 
     it("should omit signerId when not provided", async () => {
-      const mockConnector = new MockHotConnect([
+      const mockConnector = new MockNearConnect([
         { accountId: "alice.near", publicKey: "ed25519:abc123" },
       ])
 
-      const adapter = fromHotConnect(mockConnector)
+      const adapter = fromNearConnect(mockConnector)
 
       // biome-ignore lint/style/noNonNullAssertion: adapter always provides signDelegateActions
       await adapter.signDelegateActions!({
@@ -220,7 +220,7 @@ describe("Wallet Delegate Action Signing", () => {
       }
 
       // biome-ignore lint/suspicious/noExplicitAny: intentionally flat response to test normalization
-      const adapter = fromHotConnect(connector as any)
+      const adapter = fromNearConnect(connector as any)
       // biome-ignore lint/style/noNonNullAssertion: adapter always provides signDelegateActions
       const result = await adapter.signDelegateActions!({
         delegateActions: [
@@ -239,11 +239,11 @@ describe("Wallet Delegate Action Signing", () => {
     })
 
     it("should pass through already-wrapped signedDelegate format", async () => {
-      const mockConnector = new MockHotConnect([
+      const mockConnector = new MockNearConnect([
         { accountId: "test.near", publicKey: "ed25519:abc" },
       ])
 
-      const adapter = fromHotConnect(mockConnector)
+      const adapter = fromNearConnect(mockConnector)
       // biome-ignore lint/style/noNonNullAssertion: adapter always provides signDelegateActions
       const result = await adapter.signDelegateActions!({
         delegateActions: [
@@ -254,7 +254,7 @@ describe("Wallet Delegate Action Signing", () => {
         ],
       })
 
-      // MockHotConnectWallet already returns wrapped format
+      // MockNearConnectWallet already returns wrapped format
       const signed = result.signedDelegateActions[0]?.signedDelegate
       expect(signed).toBeDefined()
       // biome-ignore lint/style/noNonNullAssertion: asserted above
@@ -283,7 +283,7 @@ describe("Wallet Delegate Action Signing", () => {
         },
       }
 
-      const adapter = fromHotConnect(connector)
+      const adapter = fromNearConnect(connector)
 
       await expect(
         // biome-ignore lint/style/noNonNullAssertion: testing error path
@@ -323,7 +323,7 @@ describe("Wallet Delegate Action Signing", () => {
         },
       }
 
-      const adapter = fromHotConnect(connector)
+      const adapter = fromNearConnect(connector)
 
       await expect(
         // biome-ignore lint/style/noNonNullAssertion: testing error path

--- a/packages/near-kit/tests/wallets/integration.test.ts
+++ b/packages/near-kit/tests/wallets/integration.test.ts
@@ -5,10 +5,10 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import { Near } from "../../src/core/near.js"
 import {
-  fromHotConnect,
+  fromNearConnect,
   fromWalletSelector,
 } from "../../src/wallets/adapters.js"
-import { MockHotConnect, MockWalletSelector } from "./mock-wallets.js"
+import { MockNearConnect, MockWalletSelector } from "./mock-wallets.js"
 
 describe("Near class with wallets", () => {
   describe("With wallet-selector", () => {
@@ -120,22 +120,22 @@ describe("Near class with wallets", () => {
     })
   })
 
-  describe("With HOT Connect", () => {
-    let mockConnector: MockHotConnect
+  describe("With NEAR Connect", () => {
+    let mockConnector: MockNearConnect
     let near: Near
 
     beforeEach(() => {
-      mockConnector = new MockHotConnect([
+      mockConnector = new MockNearConnect([
         { accountId: "alice.near", publicKey: "ed25519:abc123" },
       ])
 
       near = new Near({
         network: "mainnet",
-        wallet: fromHotConnect(mockConnector),
+        wallet: fromNearConnect(mockConnector),
       })
     })
 
-    it("should use HOT Connect for call()", async () => {
+    it("should use NEAR Connect for call()", async () => {
       mockConnector.clearCallLog()
 
       await near.call(
@@ -154,7 +154,7 @@ describe("Near class with wallets", () => {
       }
     })
 
-    it("should use HOT Connect for send()", async () => {
+    it("should use NEAR Connect for send()", async () => {
       mockConnector.clearCallLog()
 
       await near.send("receiver.near", "2 NEAR")

--- a/packages/near-kit/tests/wallets/mock-wallets.ts
+++ b/packages/near-kit/tests/wallets/mock-wallets.ts
@@ -1,7 +1,7 @@
 /**
  * Mock wallet implementations for testing
  *
- * These mocks are structurally compatible with wallet-selector and HOT Connect
+ * These mocks are structurally compatible with NEAR Connect and wallet-selector
  * wallet interfaces. We use type assertions to bridge the nominal vs structural
  * typing gap.
  */
@@ -124,17 +124,17 @@ export class MockWalletSelector {
 }
 
 /**
- * Mock wallet that simulates @hot-labs/near-connect behavior
+ * Mock wallet that simulates @hot-labs/near-connect (NEAR Connect) behavior
  */
-export class MockHotConnect {
-  private _wallet: MockHotConnectWallet
+export class MockNearConnect {
+  private _wallet: MockNearConnectWallet
   private callLog: CallLogEntry[] = []
 
   constructor(accounts: WalletAccount[] = []) {
-    this._wallet = new MockHotConnectWallet(accounts)
+    this._wallet = new MockNearConnectWallet(accounts)
   }
 
-  async wallet(): Promise<MockHotConnectWallet> {
+  async wallet(): Promise<MockNearConnectWallet> {
     this.callLog.push({ method: "wallet", params: {} })
     return this._wallet
   }
@@ -159,11 +159,14 @@ export class MockHotConnect {
   }
 }
 
+/** @deprecated Use {@link MockNearConnect} instead */
+export const MockHotConnect = MockNearConnect
+
 /**
- * Mock wallet instance returned by HOT Connect
- * HOT Connect requires publicKey to always be present
+ * Mock wallet instance returned by NEAR Connect
+ * NEAR Connect requires publicKey to always be present
  */
-class MockHotConnectWallet {
+class MockNearConnectWallet {
   private accounts: Array<{ accountId: string; publicKey: string }>
   private callLog: CallLogEntry[] = []
 
@@ -174,7 +177,7 @@ class MockHotConnectWallet {
   }
 
   constructor(accounts: WalletAccount[] = []) {
-    // HOT Connect requires publicKey - ensure all accounts have it
+    // NEAR Connect requires publicKey - ensure all accounts have it
     this.accounts = accounts.map((acc) => ({
       accountId: acc.accountId,
       publicKey: acc.publicKey || "ed25519:default",
@@ -286,7 +289,7 @@ class MockHotConnectWallet {
   }
 
   setAccounts(accounts: WalletAccount[]) {
-    // HOT Connect requires publicKey - ensure all accounts have it
+    // NEAR Connect requires publicKey - ensure all accounts have it
     this.accounts = accounts.map((acc) => ({
       accountId: acc.accountId,
       publicKey: acc.publicKey || "ed25519:default",

--- a/packages/near-kit/tests/wallets/mock-wallets.ts
+++ b/packages/near-kit/tests/wallets/mock-wallets.ts
@@ -160,7 +160,7 @@ export class MockNearConnect {
 }
 
 /** @deprecated Use {@link MockNearConnect} instead */
-export const MockHotConnect = MockNearConnect
+export { MockNearConnect as MockHotConnect }
 
 /**
  * Mock wallet instance returned by NEAR Connect

--- a/packages/near-kit/tests/wallets/type-compatibility.test.ts
+++ b/packages/near-kit/tests/wallets/type-compatibility.test.ts
@@ -144,7 +144,7 @@ describe("Type Compatibility Verification", () => {
       }
 
       // Verify structure matches what NEAR Connect expects (requires publicKey)
-      function processHCAccount(account: {
+      function processConnectorAccount(account: {
         accountId: string
         publicKey: string
       }) {
@@ -152,7 +152,7 @@ describe("Type Compatibility Verification", () => {
       }
 
       // Works when publicKey is present
-      const result = processHCAccount(
+      const result = processConnectorAccount(
         ourAccount as { accountId: string; publicKey: string },
       )
       expect(result).toBe("alice.near:ed25519:abc123")

--- a/packages/near-kit/tests/wallets/type-compatibility.test.ts
+++ b/packages/near-kit/tests/wallets/type-compatibility.test.ts
@@ -137,13 +137,13 @@ describe("Type Compatibility Verification", () => {
       expect(result).toBe("alice.near:ed25519:abc123")
     })
 
-    it("our WalletAccount matches HOT Connect Account structure", () => {
+    it("our WalletAccount matches NEAR Connect Account structure", () => {
       const ourAccount: WalletAccount = {
         accountId: "alice.near",
         publicKey: "ed25519:abc123",
       }
 
-      // Verify structure matches what HOT Connect expects (requires publicKey)
+      // Verify structure matches what NEAR Connect expects (requires publicKey)
       function processHCAccount(account: {
         accountId: string
         publicKey: string


### PR DESCRIPTION
## Summary

- Rename `fromHotConnect` → `fromNearConnect` with deprecated alias for backwards compat
- Rename internal `HotConnect*` types → `NearConnect*` with deprecated aliases
- Add `@deprecated` JSDoc to `fromWalletSelector` (NEAR Wallet Selector is deprecated)
- Update all tests and mocks to use new names

## Test plan

- [x] `bun run lint` passes
- [x] `bun run build` passes
- [x] All 60 wallet tests pass
- [x] All 943 unit tests pass