### PR TITLE
feat(schemas): add near-kit/schemas subpath export for schemas

### DIFF
--- a/.changeset/export-zod-schemas.md
+++ b/.changeset/export-zod-schemas.md
@@ -1,0 +1,7 @@
+---
+"near-kit": minor
+---
+
+Add `near-kit/schemas` subpath export for Zod validation schemas
+
+Export `AccountIdSchema`, `AmountSchema`, `GasSchema`, `PublicKeySchema`, `PrivateKeySchema` and their inferred types via `import { ... } from 'near-kit/schemas'`. Useful for composing your own validation logic without duplicating NEAR's validation rules.

--- a/packages/near-kit/package.json
+++ b/packages/near-kit/package.json
@@ -27,6 +27,10 @@
     "./keys/native": {
       "import": "./dist/keys/native-keystore.js",
       "types": "./dist/keys/native-keystore.d.ts"
+    },
+    "./schemas": {
+      "import": "./dist/schemas/index.js",
+      "types": "./dist/schemas/index.d.ts"
     }
   },
   "files": [

--- a/packages/near-kit/src/schemas/index.ts
+++ b/packages/near-kit/src/schemas/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Zod validation schemas for NEAR types.
+ *
+ * Useful for composing your own validation logic — form validation,
+ * API input schemas, config parsing, etc.
+ *
+ * @example
+ * ```typescript
+ * import { AccountIdSchema, AmountSchema } from 'near-kit/schemas'
+ * import { z } from 'zod'
+ *
+ * // Compose into your own schema
+ * const TransferFormSchema = z.object({
+ *   senderId: AccountIdSchema,
+ *   receiverId: AccountIdSchema,
+ *   amount: AmountSchema,
+ * })
+ * ```
+ */
+
+export {
+  type AccountId,
+  AccountIdSchema,
+  type Amount,
+  AmountSchema,
+  type Gas,
+  GasSchema,
+  type PrivateKey,
+  PrivateKeySchema,
+  type PrivateKeyString,
+  PublicKeySchema,
+  type PublicKeyString,
+} from "../utils/validation.js"


### PR DESCRIPTION

- [x] Add near-kit/schemas subpath export exposing Zod validation schemas (AccountIdSchema, AmountSchema, GasSchema, PublicKeySchema, PrivateKeySchema) and their inferred types
- [x] Enables consumers to compose their own validation logic, synced with near-kit validation logic