### PR TITLE
fix(wallets): align with hot connect types

### DIFF
--- a/.changeset/fix-near-connect-type-alignment.md
+++ b/.changeset/fix-near-connect-type-alignment.md
@@ -1,0 +1,14 @@
+---
+"near-kit": minor
+---
+
+Fix NearConnectWallet / NearConnectConnector types to match @hot-labs/near-connect reality
+
+- `manifest` is now required (was optional) — all wallets always provide it
+- `signDelegateActions` is now required on NearConnectWallet (was optional) — all wallets since v0.9.0 implement it
+- `getAccounts` return type `publicKey` is now optional (`string | undefined`) — hardware wallets and some wallet types don't always return it
+- Fixed `signDelegateAction` → `signDelegateActions` typo in manifest features — the feature gate check was dead code because the property name didn't match @hot-labs/near-connect's `WalletFeatures.signDelegateActions`
+- `NearConnectSignDelegateActionsResponse` now returns `string[]` (base64-encoded) matching near-connect's actual `SignDelegateActionsResponse` type — the adapter decodes these using `decodeSignedDelegateAction`
+- Adapter runtime guard now only checks `manifest.features.signDelegateActions` flag
+
+These changes eliminate the need for `as any` casts when passing `@hot-labs/near-connect` connectors to `fromNearConnect()`.

--- a/.changeset/fix-near-connect-type-alignment.md
+++ b/.changeset/fix-near-connect-type-alignment.md
@@ -5,10 +5,12 @@
 Fix NearConnectWallet / NearConnectConnector types to match @hot-labs/near-connect reality
 
 - `manifest` is now required (was optional) — all wallets always provide it
-- `signDelegateActions` is now required on NearConnectWallet (was optional) — all wallets since v0.9.0 implement it
+- `signDelegateActions` is now required on NearConnectWallet (was optional) — all wallets since v0.10.0 implement it
 - `getAccounts` return type `publicKey` is now optional (`string | undefined`) — hardware wallets and some wallet types don't always return it
 - Fixed `signDelegateAction` → `signDelegateActions` typo in manifest features — the feature gate check was dead code because the property name didn't match @hot-labs/near-connect's `WalletFeatures.signDelegateActions`
 - `NearConnectSignDelegateActionsResponse` now returns `string[]` (base64-encoded) matching near-connect's actual `SignDelegateActionsResponse` type — the adapter decodes these using `decodeSignedDelegateAction`
 - Adapter runtime guard now only checks `manifest.features.signDelegateActions` flag
 
 These changes eliminate the need for `as any` casts when passing `@hot-labs/near-connect` connectors to `fromNearConnect()`.
+
+Bumped `@hot-labs/near-connect` peer dependency from `>=0.9.0` to `>=0.11.0` — types now align with v0.11.0+ which changed `WalletFeatures.signDelegateAction` → `signDelegateActions` and `SignDelegateActionsResponse` from structured objects to `string[]`.

--- a/packages/near-kit/package.json
+++ b/packages/near-kit/package.json
@@ -59,7 +59,7 @@
     "directory": "packages/near-kit"
   },
   "peerDependencies": {
-    "@hot-labs/near-connect": ">=0.9.0",
+    "@hot-labs/near-connect": ">=0.11.0",
     "@near-wallet-selector/core": ">=8.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/near-kit/src/wallets/adapters.ts
+++ b/packages/near-kit/src/wallets/adapters.ts
@@ -12,12 +12,14 @@
  * for verification.
  */
 
+import { sha256 } from "@noble/hashes/sha2.js"
+import { base64 } from "@scure/base"
+import { decodeSignedDelegateAction } from "../core/schema.js"
 import type {
   Action,
   FinalExecutionOutcome,
   SignDelegateActionsParams,
   SignDelegateActionsResult,
-  SignedDelegateAction,
   SignedMessage,
   WalletConnection,
 } from "../core/types.js"
@@ -289,7 +291,7 @@ export function fromNearConnect(
 
       return accounts.map((acc) => ({
         accountId: acc.accountId,
-        publicKey: acc.publicKey,
+        ...(acc.publicKey !== undefined && { publicKey: acc.publicKey }),
       }))
     },
 
@@ -321,10 +323,7 @@ export function fromNearConnect(
     ): Promise<SignDelegateActionsResult> {
       const wallet = await connector.wallet()
 
-      if (
-        !wallet.signDelegateActions ||
-        wallet.manifest?.features?.signDelegateAction === false
-      ) {
+      if (wallet.manifest.features?.signDelegateActions === false) {
         throw new Error(
           "Connected wallet does not support delegate action signing. " +
             "Make sure you're using a wallet that supports meta-transactions " +
@@ -343,24 +342,14 @@ export function fromNearConnect(
         delegateActions: nearConnectDelegateActions,
       })
 
-      // Bridge response shape: near-connect returns @near-js/transactions
-      // SignedDelegate (flat { delegateAction, signature }) whereas near-kit
-      // uses the borsh-schema wrapper { signedDelegate: { delegateAction, signature } }.
+      // Bridge response: near-connect returns base64-encoded signed delegate
+      // actions as strings. Decode each into near-kit's structured format.
       return {
-        signedDelegateActions: response.signedDelegateActions.map((result) => {
-          const walletSignedDelegate = result.signedDelegate as Record<
-            string,
-            unknown
-          >
-          const signedDelegate =
-            "signedDelegate" in walletSignedDelegate
-              ? (result.signedDelegate as SignedDelegateAction)
-              : ({
-                  signedDelegate: walletSignedDelegate,
-                } as unknown as SignedDelegateAction)
-
+        signedDelegateActions: response.signedDelegateActions.map((encoded) => {
+          const signedDelegate = decodeSignedDelegateAction(encoded)
+          const bytes = base64.decode(encoded)
           return {
-            delegateHash: result.delegateHash,
+            delegateHash: sha256(bytes),
             signedDelegate,
           }
         }),

--- a/packages/near-kit/src/wallets/types.ts
+++ b/packages/near-kit/src/wallets/types.ts
@@ -7,11 +7,7 @@
  * @internal
  */
 
-import type {
-  FinalExecutionOutcome,
-  SignDelegateActionsResult,
-  SignedMessage,
-} from "../core/types.js"
+import type { FinalExecutionOutcome, SignedMessage } from "../core/types.js"
 
 /**
  * NEAR Connect action types, mirroring `@hot-labs/near-connect`'s
@@ -117,22 +113,23 @@ export type NearConnectSignDelegateActionsParams = {
 
 /**
  * NEAR Connect's response for signDelegateActions (v0.9.0+).
+ * Returns base64-encoded signed delegate actions.
  * @internal
  */
 export type NearConnectSignDelegateActionsResponse = {
-  signedDelegateActions: SignDelegateActionsResult["signedDelegateActions"]
+  signedDelegateActions: string[]
 }
 
 export type NearConnectWallet = {
-  manifest?: {
+  manifest: {
     features?: {
-      signDelegateAction?: boolean
+      signDelegateActions?: boolean
     }
   }
   getAccounts(data?: { network?: string }): Promise<
     Array<{
       accountId: string
-      publicKey: string
+      publicKey?: string
     }>
   >
   signAndSendTransaction(params: {
@@ -147,7 +144,7 @@ export type NearConnectWallet = {
     nonce: Uint8Array
     network?: string
   }): Promise<SignedMessage>
-  signDelegateActions?(
+  signDelegateActions(
     params: NearConnectSignDelegateActionsParams,
   ): Promise<NearConnectSignDelegateActionsResponse>
 }

--- a/packages/near-kit/tests/wallets/delegate-signing.test.ts
+++ b/packages/near-kit/tests/wallets/delegate-signing.test.ts
@@ -170,75 +170,7 @@ describe("Wallet Delegate Action Signing", () => {
       }
     })
 
-    it("should normalize flat signedDelegate response to wrapped format", async () => {
-      // Simulate a wallet that returns @near-js/transactions flat format:
-      // { delegateAction, signature } instead of { signedDelegate: { delegateAction, signature } }
-      const flatWallet = {
-        manifest: { features: { signDelegateAction: true } },
-        async getAccounts() {
-          return [{ accountId: "test.near", publicKey: "ed25519:abc" }]
-        },
-        async signAndSendTransaction() {
-          // biome-ignore lint/suspicious/noExplicitAny: mock
-          return {} as any
-        },
-        async signMessage() {
-          // biome-ignore lint/suspicious/noExplicitAny: mock
-          return {} as any
-        },
-        async signDelegateActions() {
-          return {
-            signedDelegateActions: [
-              {
-                delegateHash: new Uint8Array(32),
-                // Flat format from @near-js/transactions — no nested signedDelegate key
-                signedDelegate: {
-                  delegateAction: {
-                    senderId: "test.near",
-                    receiverId: "contract.near",
-                    actions: [],
-                    nonce: 1n,
-                    maxBlockHeight: 1000n,
-                    publicKey: {
-                      ed25519Key: { data: Array.from(new Uint8Array(32)) },
-                    },
-                  },
-                  signature: {
-                    ed25519Signature: { data: Array.from(new Uint8Array(64)) },
-                  },
-                },
-              },
-            ],
-          }
-        },
-      }
-
-      const connector = {
-        async wallet() {
-          return flatWallet
-        },
-      }
-
-      // biome-ignore lint/suspicious/noExplicitAny: intentionally flat response to test normalization
-      const adapter = fromNearConnect(connector as any)
-      // biome-ignore lint/style/noNonNullAssertion: adapter always provides signDelegateActions
-      const result = await adapter.signDelegateActions!({
-        delegateActions: [
-          {
-            actions: [actions.transfer(BigInt(1000))],
-            receiverId: "contract.near",
-          },
-        ],
-      })
-
-      // Should wrap flat format into { signedDelegate: { delegateAction, signature } }
-      const signed = result.signedDelegateActions[0]?.signedDelegate
-      expect(signed).toBeDefined()
-      // biome-ignore lint/style/noNonNullAssertion: asserted above
-      expect("signedDelegate" in signed!).toBe(true)
-    })
-
-    it("should pass through already-wrapped signedDelegate format", async () => {
+    it("should decode base64 signed delegate actions from wallet response", async () => {
       const mockConnector = new MockNearConnect([
         { accountId: "test.near", publicKey: "ed25519:abc" },
       ])
@@ -254,15 +186,48 @@ describe("Wallet Delegate Action Signing", () => {
         ],
       })
 
-      // MockNearConnectWallet already returns wrapped format
+      // Adapter should decode base64 strings into structured format
       const signed = result.signedDelegateActions[0]?.signedDelegate
       expect(signed).toBeDefined()
       // biome-ignore lint/style/noNonNullAssertion: asserted above
       expect("signedDelegate" in signed!).toBe(true)
+      expect(result.signedDelegateActions[0]?.delegateHash).toBeInstanceOf(
+        Uint8Array,
+      )
+    })
+
+    it("should handle multiple base64 encoded delegate actions", async () => {
+      const mockConnector = new MockNearConnect([
+        { accountId: "test.near", publicKey: "ed25519:abc" },
+      ])
+
+      const adapter = fromNearConnect(mockConnector)
+      // biome-ignore lint/style/noNonNullAssertion: adapter always provides signDelegateActions
+      const result = await adapter.signDelegateActions!({
+        delegateActions: [
+          {
+            actions: [actions.transfer(BigInt(1000))],
+            receiverId: "bob.near",
+          },
+          {
+            actions: [actions.transfer(BigInt(2000))],
+            receiverId: "carol.near",
+          },
+        ],
+      })
+
+      // Each base64 string should be decoded into a structured result
+      expect(result.signedDelegateActions).toHaveLength(2)
+      for (const item of result.signedDelegateActions) {
+        expect(item.signedDelegate).toBeDefined()
+        expect(item.delegateHash).toBeInstanceOf(Uint8Array)
+        expect("signedDelegate" in item.signedDelegate).toBe(true)
+      }
     })
 
     it("should throw when wallet does not support signDelegateActions", async () => {
       const walletWithout = {
+        manifest: { features: { signDelegateActions: false } },
         async getAccounts() {
           return [{ accountId: "test.near", publicKey: "ed25519:abc" }]
         },
@@ -274,12 +239,12 @@ describe("Wallet Delegate Action Signing", () => {
           // biome-ignore lint/suspicious/noExplicitAny: mock
           return {} as any
         },
-        // No signDelegateActions method
       }
 
       const connector = {
         async wallet() {
-          return walletWithout
+          // biome-ignore lint/suspicious/noExplicitAny: simulating non-compliant wallet at runtime
+          return walletWithout as any
         },
       }
 
@@ -300,7 +265,7 @@ describe("Wallet Delegate Action Signing", () => {
 
     it("should throw when manifest explicitly disables signDelegateActions", async () => {
       const walletDisabled = {
-        manifest: { features: { signDelegateAction: false } },
+        manifest: { features: { signDelegateActions: false } },
         async getAccounts() {
           return [{ accountId: "test.near", publicKey: "ed25519:abc" }]
         },

--- a/packages/near-kit/tests/wallets/mock-wallets.ts
+++ b/packages/near-kit/tests/wallets/mock-wallets.ts
@@ -6,9 +6,9 @@
  * typing gap.
  */
 
+import { encodeSignedDelegateAction } from "../../src/core/schema.js"
 import type {
   FinalExecutionOutcome,
-  SignedDelegateAction,
   SignedMessage,
   WalletAccount,
 } from "../../src/core/types.js"
@@ -172,7 +172,7 @@ class MockNearConnectWallet {
 
   manifest = {
     features: {
-      signDelegateAction: true,
+      signDelegateActions: true,
     },
   }
 
@@ -185,7 +185,7 @@ class MockNearConnectWallet {
   }
 
   async getAccounts(): Promise<
-    Array<{ accountId: string; publicKey: string }>
+    Array<{ accountId: string; publicKey?: string }>
   > {
     this.callLog.push({ method: "getAccounts", params: {} })
     return this.accounts
@@ -245,38 +245,31 @@ class MockNearConnectWallet {
   }
 
   async signDelegateActions(params: SignDelegateActionsParams): Promise<{
-    signedDelegateActions: Array<{
-      delegateHash: Uint8Array
-      signedDelegate: SignedDelegateAction
-    }>
+    signedDelegateActions: string[]
   }> {
     this.callLog.push({ method: "signDelegateActions", params })
 
     return {
-      signedDelegateActions: params.delegateActions.map((da) => ({
-        delegateHash: new Uint8Array(32),
-        signedDelegate: {
+      signedDelegateActions: params.delegateActions.map(() =>
+        encodeSignedDelegateAction({
           signedDelegate: {
             delegateAction: {
               senderId:
                 params.signerId || this.accounts[0]?.accountId || "test.near",
-              receiverId: da.receiverId,
-              // biome-ignore lint/suspicious/noExplicitAny: mock delegate action
-              actions: da.actions as any,
+              receiverId: "test.near",
+              actions: [{ transfer: { deposit: 0n } }],
               nonce: 1n,
               maxBlockHeight: 1000n,
               publicKey: {
-                keyType: 0,
-                data: new Uint8Array(32),
+                ed25519Key: { data: new Uint8Array(32) },
               },
             },
             signature: {
-              keyType: 0,
-              data: new Uint8Array(64),
+              ed25519Signature: { data: new Uint8Array(64) },
             },
           },
-        } as unknown as SignedDelegateAction,
-      })),
+        }),
+      ),
     }
   }
 


### PR DESCRIPTION
Eliminating "as any" type casts from my code, caused by a misalignment with near-connect

- [x] Bumped `@hot-labs/near-connect` peer dependency from `>=0.9.0` to `>=0.11.0` — types now align with v0.11.0+ which changed `WalletFeatures.signDelegateAction` → `signDelegateActions` and `SignDelegateActionsResponse` from structured objects to `string[]`. 
- [x] Fix NearConnectWallet / NearConnectConnector types to match @hot-labs/near-connect v0.11.1, eliminating as any casts
- [x] manifest is now required (was optional) — all wallets always provide it
- [x] signDelegateActions is now required on NearConnectWallet (was optional) — all wallets since v0.9.0 implement it
getAccounts return type publicKey is now optional (string | undefined) — hardware wallets and some wallet types don't always return it
- [x] Fixed signDelegateAction → signDelegateActions typo in manifest features — the feature gate check was dead code because the property name didn't match WalletFeatures.signDelegateActions
- [x] NearConnectSignDelegateActionsResponse now returns string[] (base64-encoded) matching near-connect's actual response — adapter decodes via decodeSignedDelegateAction