### PR TITLE
feat(rpc): expose nonce_mode on transaction views

### DIFF
--- a/.changeset/nonce-mode-view.md
+++ b/.changeset/nonce-mode-view.md
@@ -1,0 +1,5 @@
+---
+"near-kit": minor
+---
+
+Expose `nonce_mode` on transaction views (new in nearcore 2.12)

--- a/packages/near-kit/src/core/rpc/rpc-schemas.ts
+++ b/packages/near-kit/src/core/rpc/rpc-schemas.ts
@@ -410,6 +410,16 @@ export const ActionSchema = z.union([
 ])
 
 /**
+ * Nonce mode (new in nearcore 2.12)
+ *
+ * Controls how the transaction nonce relates to the access key nonce:
+ * - "monotonic": any nonce strictly greater than the current access key nonce
+ *   is accepted (default behavior)
+ * - "strict": nonce must be exactly `ak_nonce + 1`, enforcing sequential ordering
+ */
+export const NonceModeSchema = z.enum(["monotonic", "strict"])
+
+/**
  * Transaction schema (as returned by RPC)
  */
 export const TransactionSchema = z.object({
@@ -421,6 +431,7 @@ export const TransactionSchema = z.object({
   signature: z.string(),
   hash: z.string(),
   priority_fee: z.number().optional(),
+  nonce_mode: NonceModeSchema.nullable().optional(),
 })
 
 /**
@@ -573,6 +584,7 @@ export type ExecutionOutcomeWithId = z.infer<
   typeof ExecutionOutcomeWithIdSchema
 >
 export type RpcAction = z.infer<typeof ActionSchema>
+export type NonceMode = z.infer<typeof NonceModeSchema>
 export type RpcTransaction = z.infer<typeof TransactionSchema>
 export type FinalExecutionOutcome = z.infer<typeof FinalExecutionOutcomeSchema>
 export type Receipt = z.infer<typeof ReceiptSchema>

--- a/packages/near-kit/src/core/types.ts
+++ b/packages/near-kit/src/core/types.ts
@@ -219,6 +219,7 @@ export type {
   FinalExecutionOutcomeWithReceipts,
   FinalExecutionOutcomeWithReceiptsMap,
   MerklePathItem,
+  NonceMode,
   Receipt,
   RpcAction,
   RpcTransaction,

--- a/packages/near-kit/tests/unit/rpc-schemas.test.ts
+++ b/packages/near-kit/tests/unit/rpc-schemas.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for RPC response schemas
+ */
+
+import { describe, expect, test } from "vitest"
+import { TransactionSchema } from "../../src/core/rpc/rpc-schemas.js"
+
+const baseTransaction = {
+  signer_id: "alice.near",
+  public_key: "ed25519:8nFkHgRePSGD9UsK3Hx6nWKXGQ7Kd7k3k7k3k7k3k7k3",
+  nonce: 42,
+  receiver_id: "bob.near",
+  actions: [],
+  signature: "ed25519:3D4c2v8K5x...",
+  hash: "11111111111111111111111111111111",
+}
+
+describe("TransactionSchema", () => {
+  describe("nonce_mode (new in nearcore 2.12)", () => {
+    test("should parse a transaction with nonce_mode 'strict'", () => {
+      const result = TransactionSchema.parse({
+        ...baseTransaction,
+        nonce_mode: "strict",
+      })
+
+      expect(result.nonce_mode).toBe("strict")
+    })
+
+    test("should parse a transaction with nonce_mode 'monotonic'", () => {
+      const result = TransactionSchema.parse({
+        ...baseTransaction,
+        nonce_mode: "monotonic",
+      })
+
+      expect(result.nonce_mode).toBe("monotonic")
+    })
+
+    test("should parse a transaction with nonce_mode null", () => {
+      const result = TransactionSchema.parse({
+        ...baseTransaction,
+        nonce_mode: null,
+      })
+
+      expect(result.nonce_mode).toBeNull()
+    })
+
+    test("should parse a transaction without nonce_mode", () => {
+      const result = TransactionSchema.parse(baseTransaction)
+
+      expect(result.nonce_mode).toBeUndefined()
+    })
+
+    test("should reject an invalid nonce_mode value", () => {
+      expect(() =>
+        TransactionSchema.parse({
+          ...baseTransaction,
+          nonce_mode: "sequential",
+        }),
+      ).toThrow()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- nearcore 2.12 added a `nonce_mode` field to `SignedTransactionView` in RPC responses; the zod `TransactionSchema` was silently stripping this unknown field.
- Adds `NonceModeSchema = z.enum(["monotonic", "strict"])` and exposes it on `TransactionSchema` as `nonce_mode: NonceModeSchema.nullable().optional()` (nullable + optional, since the field may be `null` or absent).
- Values: `"monotonic"` (any nonce strictly greater than the current access key nonce — default) and `"strict"` (nonce must be exactly `ak_nonce + 1`, sequential ordering), per nearcore 2.12.
- Re-exports the inferred `NonceMode` type alongside `RpcTransaction`/`RpcAction` in `core/types.ts`.

## Test plan

- [x] New unit tests in `tests/unit/rpc-schemas.test.ts` cover `nonce_mode` = `"strict"`, `"monotonic"`, `null`, absent, and an invalid value (rejected).
- [x] `bun run test:unit` — 948 passed
- [x] `bun run lint` — clean
- [x] `bun run build` — passes