### PR TITLE
build(sandbox): update nearcore to 2.12.0

### DIFF
--- a/.changeset/nearcore-2.12.0.md
+++ b/.changeset/nearcore-2.12.0.md
@@ -1,0 +1,5 @@
+---
+"near-kit": patch
+---
+
+Update sandbox to nearcore 2.12.0

--- a/packages/near-kit/src/sandbox/sandbox.ts
+++ b/packages/near-kit/src/sandbox/sandbox.ts
@@ -23,7 +23,7 @@ import { pipeline } from "node:stream/promises"
 import type { ReadableStream as WebReadableStream } from "node:stream/web"
 import * as tar from "tar"
 
-const DEFAULT_VERSION = "2.11.1"
+const DEFAULT_VERSION = "2.12.0"
 const BINARY_NAME = "near-sandbox"
 const ARCHIVE_NAME = "near-sandbox.tar.gz"
 const DOWNLOAD_BASE =


### PR DESCRIPTION
## Summary

- Bump sandbox `DEFAULT_VERSION` from `2.11.1` to `2.12.0` in `packages/near-kit/src/sandbox/sandbox.ts`
- Add changeset (`near-kit`: patch)

[Release notes](https://github.com/near/nearcore/releases/tag/2.12.0)

## Test plan

Ran locally against the freshly downloaded 2.12.0 binary (`neard release 2.12.0`, protocol 84):

- `tests/unit` — 943 passed
- `tests/integration/send-transaction.test.ts` — 8 passed (RPC response schema validation across NONE/INCLUDED/EXECUTED/FINAL wait modes)
- `tests/integration/sandbox.test.ts` + `tests/integration/near-client.test.ts` — 57 passed (patchState, fastForward, snapshots, view/call, transactions)

No 2.12 incompatibilities found — no RPC response shape / zod schema breakage observed.

## Note

Branch name `deps/nearcore-2.12.0` matches the pattern produced by the `check-nearcore-release` scheduled workflow, so the daily job will detect this existing PR and skip creating a duplicate.