### PR TITLE
feat(rpc): add receiptToTx for EXPERIMENTAL_receipt_to_tx

### DIFF
--- a/.changeset/receipt-to-tx.md
+++ b/.changeset/receipt-to-tx.md
@@ -1,0 +1,5 @@
+---
+"near-kit": minor
+---
+
+Add `receiptToTx()` to RpcClient for the new `EXPERIMENTAL_receipt_to_tx` endpoint (nearcore 2.12)

--- a/.changeset/receipt-to-tx.md
+++ b/.changeset/receipt-to-tx.md
@@ -2,4 +2,4 @@
 "near-kit": minor
 ---
 
-Add `receiptToTx()` to RpcClient for the new `EXPERIMENTAL_receipt_to_tx` endpoint (nearcore 2.12)
+Add `receiptToTx()` to the RPC client for the new `EXPERIMENTAL_receipt_to_tx` endpoint (nearcore 2.12), accessible via `near.rpc.receiptToTx()`. The configured low-level RPC client is now exposed through the `near.rpc` getter for advanced calls not wrapped by `Near`.

--- a/docs/in-depth/advanced-transactions.mdx
+++ b/docs/in-depth/advanced-transactions.mdx
@@ -184,14 +184,10 @@ await near.transaction("alice.near")
 
 ## 7. Mapping a Receipt Back to its Transaction
 
-When you only have a receipt ID (for example, from a cross-contract call), you can find the transaction that originated it using the low-level `RpcClient`. This calls the experimental `EXPERIMENTAL_receipt_to_tx` endpoint and **requires nearcore >= 2.12**.
+When you only have a receipt ID (for example, from a cross-contract call), you can find the transaction that originated it via `near.rpc` — the low-level RPC client exposed for calls not wrapped by `Near`. This calls the experimental `EXPERIMENTAL_receipt_to_tx` endpoint and **requires nearcore >= 2.12**.
 
 ```typescript
-import { RpcClient } from "near-kit"
-
-const rpc = new RpcClient("https://rpc.mainnet.near.org")
-
-const { transaction_hash, sender_account_id } = await rpc.receiptToTx(
+const { transaction_hash, sender_account_id } = await near.rpc.receiptToTx(
   "9ADoP8t3kRkV6JqYy3a6mJZ1uXuJ4Z3o2bF7tQwErTy"
 )
 ```

--- a/docs/in-depth/advanced-transactions.mdx
+++ b/docs/in-depth/advanced-transactions.mdx
@@ -181,3 +181,19 @@ await near.transaction("alice.near")
   .send({ waitUntil: "FINAL" });
 ```
 </Tip>
+
+## 7. Mapping a Receipt Back to its Transaction
+
+When you only have a receipt ID (for example, from a cross-contract call), you can find the transaction that originated it using the low-level `RpcClient`. This calls the experimental `EXPERIMENTAL_receipt_to_tx` endpoint and **requires nearcore >= 2.12**.
+
+```typescript
+import { RpcClient } from "near-kit"
+
+const rpc = new RpcClient("https://rpc.mainnet.near.org")
+
+const { transaction_hash, sender_account_id } = await rpc.receiptToTx(
+  "9ADoP8t3kRkV6JqYy3a6mJZ1uXuJ4Z3o2bF7tQwErTy"
+)
+```
+
+It throws an `UnknownReceiptError` if the node doesn't know the receipt.

--- a/packages/near-kit/src/core/near.ts
+++ b/packages/near-kit/src/core/near.ts
@@ -55,7 +55,7 @@ import type {
  * `docs/01-getting-started.md` and `docs/02-core-concepts.md`.
  */
 export class Near {
-  private rpc!: RpcClient
+  private _rpc!: RpcClient
   private keyStore!: KeyStore
   private signer?: Signer
   private wallet?: WalletConnection
@@ -79,6 +79,25 @@ export class Near {
   }
 
   /**
+   * The configured low-level JSON-RPC client.
+   *
+   * Use this as an escape hatch for advanced or low-level RPC calls that are
+   * not wrapped by convenience methods on `Near` — for example
+   * {@link RpcClient.receiptToTx}, {@link RpcClient.getBlock}, or
+   * {@link RpcClient.getGasPrice}. The returned client is already configured
+   * with this instance's network URL, headers, and retry settings.
+   *
+   * @example
+   * ```typescript
+   * const { transaction_hash, sender_account_id } =
+   *   await near.rpc.receiptToTx("9ADoP8t3kRkV6JqYy3a6mJZ1uXuJ4Z3o2bF7tQwErTy")
+   * ```
+   */
+  get rpc(): RpcClient {
+    return this._rpc
+  }
+
+  /**
    * Initialize RPC client from configuration
    * @internal
    */
@@ -87,7 +106,7 @@ export class Near {
   ): void {
     const networkConfig = resolveNetworkConfig(validatedConfig.network)
     const rpcUrl = validatedConfig.rpcUrl || networkConfig.rpcUrl
-    this.rpc = new RpcClient(
+    this._rpc = new RpcClient(
       rpcUrl,
       validatedConfig.headers,
       validatedConfig.retryConfig,
@@ -266,7 +285,7 @@ export class Near {
     args: object | Uint8Array = {},
     options?: BlockReference,
   ): Promise<T | undefined> {
-    const result = await this.rpc.viewFunction(
+    const result = await this._rpc.viewFunction(
       contractId,
       methodName,
       args,
@@ -556,7 +575,7 @@ export class Near {
     accountId: string,
     options?: BlockReference,
   ): Promise<string> {
-    const account = await this.rpc.getAccount(accountId, options)
+    const account = await this._rpc.getAccount(accountId, options)
 
     const available = this.calculateAvailableBalance(
       account.amount,
@@ -598,7 +617,7 @@ export class Near {
     accountId: string,
     options?: BlockReference,
   ): Promise<AccountState> {
-    const account = await this.rpc.getAccount(accountId, options)
+    const account = await this._rpc.getAccount(accountId, options)
 
     const available = this.calculateAvailableBalance(
       account.amount,
@@ -652,7 +671,7 @@ export class Near {
     options?: BlockReference,
   ): Promise<boolean> {
     try {
-      await this.rpc.getAccount(accountId, options)
+      await this._rpc.getAccount(accountId, options)
       return true
     } catch {
       return false
@@ -686,7 +705,7 @@ export class Near {
     options?: BlockReference,
   ): Promise<AccessKeyView | null> {
     try {
-      return await this.rpc.getAccessKey(accountId, publicKey, options)
+      return await this._rpc.getAccessKey(accountId, publicKey, options)
     } catch {
       return null
     }
@@ -716,7 +735,7 @@ export class Near {
     accountId: string,
     options?: BlockReference,
   ): Promise<AccessKeyListResponse> {
-    return this.rpc.getAccessKeys(accountId, options)
+    return this._rpc.getAccessKeys(accountId, options)
   }
 
   /**
@@ -772,7 +791,7 @@ export class Near {
       ? FinalExecutionOutcomeWithReceiptsMap[W]
       : never
   > {
-    return this.rpc.getTransactionStatus(
+    return this._rpc.getTransactionStatus(
       txHash,
       senderAccountId,
       waitUntil,
@@ -789,7 +808,7 @@ export class Near {
    * @returns The full network status response from the RPC.
    */
   async getStatus(): Promise<StatusResponse> {
-    return this.rpc.getStatus()
+    return this._rpc.getStatus()
   }
 
   /**
@@ -840,7 +859,7 @@ export class Near {
   transaction(signerId: string): TransactionBuilder {
     return new TransactionBuilder(
       signerId,
-      this.rpc,
+      this._rpc,
       this.keyStore,
       this.signer,
       this.defaultWaitUntil,

--- a/packages/near-kit/src/core/rpc/rpc-schemas.ts
+++ b/packages/near-kit/src/core/rpc/rpc-schemas.ts
@@ -202,6 +202,17 @@ export const AccessKeyListResponseSchema = z.object({
 })
 
 /**
+ * Receipt-to-transaction response schema (for EXPERIMENTAL_receipt_to_tx)
+ *
+ * Maps a receipt ID back to its originating transaction. Both fields are
+ * required by the RPC (nearcore >= 2.12).
+ */
+export const ReceiptToTxResponseSchema = z.object({
+  transaction_hash: z.string(),
+  sender_account_id: z.string(),
+})
+
+/**
  * RPC error response schema
  * Follows the NEAR RPC error structure with name, cause, code, message, and data
  */
@@ -559,6 +570,7 @@ export type BlockView = z.infer<typeof BlockViewSchema>
 export type StatusResponse = z.infer<typeof StatusResponseSchema>
 export type GasPriceResponse = z.infer<typeof GasPriceResponseSchema>
 export type AccessKeyListResponse = z.infer<typeof AccessKeyListResponseSchema>
+export type ReceiptToTxResponse = z.infer<typeof ReceiptToTxResponseSchema>
 export type RpcErrorResponse = z.infer<typeof RpcErrorResponseSchema>
 
 /**

--- a/packages/near-kit/src/core/rpc/rpc.ts
+++ b/packages/near-kit/src/core/rpc/rpc.ts
@@ -16,6 +16,7 @@ import type {
   FinalExecutionOutcomeWithReceipts,
   FinalExecutionOutcomeWithReceiptsMap,
   GasPriceResponse,
+  ReceiptToTxResponse,
   StatusResponse,
   ViewFunctionCallResult,
 } from "../types.js"
@@ -34,6 +35,7 @@ import {
   FinalExecutionOutcomeSchema,
   FinalExecutionOutcomeWithReceiptsSchema,
   GasPriceResponseSchema,
+  ReceiptToTxResponseSchema,
   StatusResponseSchema,
   ViewFunctionCallResultSchema,
 } from "./rpc-schemas.js"
@@ -521,6 +523,30 @@ export class RpcClient {
     // Safe cast: TypeScript guarantees W is a valid key, Zod validates the structure,
     // and waitUntil determines which variant we get from the RPC
     return parsed as FinalExecutionOutcomeWithReceiptsMap[W]
+  }
+
+  /**
+   * Map a receipt back to its originating transaction via
+   * `EXPERIMENTAL_receipt_to_tx`.
+   *
+   * @remarks
+   * This is an experimental endpoint and requires nearcore >= 2.12. It looks up
+   * the transaction that produced the given receipt and returns the transaction
+   * hash and sender account ID.
+   *
+   * @param receiptId - Receipt ID (CryptoHash, base58) to look up.
+   *
+   * @returns The originating transaction's hash and sender account ID.
+   *
+   * @throws {UnknownReceiptError} If the receipt is not known to the node.
+   * @throws {NetworkError} If the network request failed.
+   */
+  async receiptToTx(receiptId: string): Promise<ReceiptToTxResponse> {
+    const result = await this.call("EXPERIMENTAL_receipt_to_tx", {
+      receipt_id: receiptId,
+    })
+
+    return ReceiptToTxResponseSchema.parse(result)
   }
 
   /**

--- a/packages/near-kit/src/core/types.ts
+++ b/packages/near-kit/src/core/types.ts
@@ -242,6 +242,7 @@ import type { FinalExecutionOutcome } from "./rpc/rpc-schemas.js"
  * - StatusResponse: Network status information
  * - GasPriceResponse: Gas price information
  * - AccessKeyListResponse: Access key list from view_access_key_list query
+ * - ReceiptToTxResponse: Originating transaction info from EXPERIMENTAL_receipt_to_tx
  * - RpcErrorResponse: RPC error response structure
  */
 export type {
@@ -253,6 +254,7 @@ export type {
   BlockView,
   ChunkHeaderView,
   GasPriceResponse,
+  ReceiptToTxResponse,
   RpcErrorResponse,
   StatusResponse,
   ViewFunctionCallResult,

--- a/packages/near-kit/src/index.ts
+++ b/packages/near-kit/src/index.ts
@@ -10,6 +10,8 @@ export { DelegateAction } from "./core/actions.js"
 export { STORAGE_AMOUNT_PER_BYTE } from "./core/constants.js"
 // Main class
 export { Near } from "./core/near.js"
+// Low-level RPC client (advanced use cases / RPC methods not wrapped by Near)
+export { RpcClient } from "./core/rpc/rpc.js"
 export {
   DELEGATE_ACTION_PREFIX,
   type DelegateActionPayloadFormat,
@@ -32,6 +34,7 @@ export type {
   NearConfig,
   NetworkConfig,
   PublicKey,
+  ReceiptToTxResponse,
   SendOptions,
   Signature,
   SignDelegateActionsParams,

--- a/packages/near-kit/src/index.ts
+++ b/packages/near-kit/src/index.ts
@@ -10,8 +10,6 @@ export { DelegateAction } from "./core/actions.js"
 export { STORAGE_AMOUNT_PER_BYTE } from "./core/constants.js"
 // Main class
 export { Near } from "./core/near.js"
-// Low-level RPC client (advanced use cases / RPC methods not wrapped by Near)
-export { RpcClient } from "./core/rpc/rpc.js"
 export {
   DELEGATE_ACTION_PREFIX,
   type DelegateActionPayloadFormat,

--- a/packages/near-kit/tests/unit/rpc-receipt-to-tx.test.ts
+++ b/packages/near-kit/tests/unit/rpc-receipt-to-tx.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for RpcClient.receiptToTx (EXPERIMENTAL_receipt_to_tx)
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { RpcClient } from "../../src/core/rpc/rpc.js"
+import { UnknownReceiptError } from "../../src/errors/index.js"
+
+describe("RpcClient.receiptToTx", () => {
+  let originalFetch: typeof global.fetch
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  test("returns parsed response and calls the right method/params", async () => {
+    const receiptId = "9ADoP8t3kRkV6JqYy3a6mJZ1uXuJ4Z3o2bF7tQwErTy"
+    const expected = {
+      transaction_hash: "7AfonAhbK4ZbdBU9VPcQdrTZVZBXE25HmZAMEABs9To1",
+      sender_account_id: "alice.near",
+    }
+
+    const mockFetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          result: expected,
+        }),
+        { status: 200 },
+      )
+    })
+
+    global.fetch = mockFetch as unknown as typeof global.fetch
+
+    const rpc = new RpcClient("https://test.rpc.near.org")
+    const result = await rpc.receiptToTx(receiptId)
+
+    expect(result).toEqual(expected)
+
+    // Verify the request method and params
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string)
+    expect(body.method).toBe("EXPERIMENTAL_receipt_to_tx")
+    expect(body.params).toEqual({ receipt_id: receiptId })
+  })
+
+  test("throws UnknownReceiptError for UNKNOWN_RECEIPT error cause", async () => {
+    const receiptId = "UnknownReceipt111111111111111111111111111111"
+
+    const mockFetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          error: {
+            name: "HANDLER_ERROR",
+            code: -32000,
+            message: "Receipt not found",
+            cause: {
+              name: "UNKNOWN_RECEIPT",
+              info: { receipt_id: receiptId },
+            },
+          },
+        }),
+        { status: 200 },
+      )
+    })
+
+    global.fetch = mockFetch as unknown as typeof global.fetch
+
+    const rpc = new RpcClient("https://test.rpc.near.org")
+
+    await expect(rpc.receiptToTx(receiptId)).rejects.toThrow(
+      UnknownReceiptError,
+    )
+
+    try {
+      await rpc.receiptToTx(receiptId)
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnknownReceiptError)
+      expect((error as UnknownReceiptError).receiptId).toBe(receiptId)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Add `receiptToTx(receiptId)` to `RpcClient`, mapping a receipt ID back to its originating transaction via the new `EXPERIMENTAL_receipt_to_tx` endpoint (nearcore >= 2.12)
- Add `ReceiptToTxResponseSchema` / `ReceiptToTxResponse` (validates `transaction_hash` + `sender_account_id`)
- Export `RpcClient` and `ReceiptToTxResponse` from the public entry so the method is reachable (no `Near`-level wrapper, matching `getBlock`/`getGasPrice`)
- Throws `UnknownReceiptError` for unknown receipts (already mapped in `parseRpcError`)
- Docs: brief section in `in-depth/advanced-transactions.mdx`

## Notes

- Endpoint requires nearcore >= 2.12. The sandbox binary is still 2.11.1, so no integration test is added here; integration coverage will follow once the sandbox 2.12 bump PR lands.

## Test plan

- [x] `bun run lint`
- [x] `bun run build`
- [x] Unit tests pass (`cd packages/near-kit && bun run test:unit`) — 945 passed, including new `rpc-receipt-to-tx.test.ts` (success path asserts method/params; UNKNOWN_RECEIPT path asserts `UnknownReceiptError`)