### PR TITLE
feat(sandbox): default to nearcore 2.13.0-rc.2

### DIFF
--- a/.changeset/sandbox-2.13.md
+++ b/.changeset/sandbox-2.13.md
@@ -1,0 +1,5 @@
+---
+"near-kit": patch
+---
+
+Update sandbox default to nearcore 2.13.0-rc.2

--- a/packages/near-kit/src/sandbox/sandbox.ts
+++ b/packages/near-kit/src/sandbox/sandbox.ts
@@ -23,7 +23,7 @@ import { pipeline } from "node:stream/promises"
 import type { ReadableStream as WebReadableStream } from "node:stream/web"
 import * as tar from "tar"
 
-const DEFAULT_VERSION = "2.12.0"
+const DEFAULT_VERSION = "2.13.0-rc.2"
 const BINARY_NAME = "near-sandbox"
 const ARCHIVE_NAME = "near-sandbox.tar.gz"
 const DOWNLOAD_BASE =


### PR DESCRIPTION
## Summary

- Bump `DEFAULT_VERSION` in `sandbox.ts` from `2.12.0` to `2.13.0-rc.2` (latest published 2.13.x; stable `2.13.0` is not released yet).
- Unblocks integration tests that need a protocol v85 node.

## Test plan

- [x] `bun run build` + `bun run typecheck` clean
- [x] `bun run test:unit` (950 passing)
- [x] Sandbox boots on the new default and round-trips an on-chain transfer; node reports `"version":"2.13.0-rc.2"`