### PR TITLE
feat(actions): add gas-key actions and permissions (NEAR 2.13)

### DIFF
--- a/.changeset/gas-key-actions.md
+++ b/.changeset/gas-key-actions.md
@@ -6,3 +6,4 @@ Add gas-key actions and permissions (NEAR 2.13 / protocol v85)
 
 - `TransferToGasKey` (borsh discriminant 12) and `WithdrawFromGasKey` (13) actions, with `.transferToGasKey()` / `.withdrawFromGasKey()` builder methods.
 - `GasKeyFullAccess` and `GasKeyFunctionCall` access-key permissions (discriminants 3 and 2) plus `GasKeyInfo`, usable via `.addKey(pk, { type: "gasKeyFullAccess", numNonces })` and `{ type: "gasKeyFunctionCall", numNonces, receiverId, methodNames }`.
+- RPC view schemas for the gas-key actions and permissions, so the default `.send()` path parses a successful 2.13 response (and `getAccessKey` accepts gas keys) without errors.

--- a/.changeset/gas-key-actions.md
+++ b/.changeset/gas-key-actions.md
@@ -6,4 +6,5 @@ Add gas-key actions and permissions (NEAR 2.13 / protocol v85)
 
 - `TransferToGasKey` (borsh discriminant 12) and `WithdrawFromGasKey` (13) actions, with `.transferToGasKey()` / `.withdrawFromGasKey()` builder methods.
 - `GasKeyFullAccess` and `GasKeyFunctionCall` access-key permissions (discriminants 3 and 2) plus `GasKeyInfo`, usable via `.addKey(pk, { type: "gasKeyFullAccess", numNonces })` and `{ type: "gasKeyFunctionCall", numNonces, receiverId, methodNames }`.
-- RPC view schemas for the gas-key actions and permissions, so the default `.send()` path parses a successful 2.13 response (and `getAccessKey` accepts gas keys) without errors.
+
+Together with the gas-key RPC view schemas, the default `.send()` path parses a successful 2.13 response (and `getAccessKey` accepts gas keys) without errors.

--- a/.changeset/gas-key-actions.md
+++ b/.changeset/gas-key-actions.md
@@ -1,0 +1,8 @@
+---
+"near-kit": minor
+---
+
+Add gas-key actions and permissions (NEAR 2.13 / protocol v85)
+
+- `TransferToGasKey` (borsh discriminant 12) and `WithdrawFromGasKey` (13) actions, with `.transferToGasKey()` / `.withdrawFromGasKey()` builder methods.
+- `GasKeyFullAccess` and `GasKeyFunctionCall` access-key permissions (discriminants 3 and 2) plus `GasKeyInfo`, usable via `.addKey(pk, { type: "gasKeyFullAccess", numNonces })` and `{ type: "gasKeyFunctionCall", numNonces, receiverId, methodNames }`.

--- a/packages/near-kit/src/core/actions.ts
+++ b/packages/near-kit/src/core/actions.ts
@@ -282,17 +282,28 @@ export function gasKeyFullAccess(numNonces: number): AccessKeyPermissionBorsh {
  * contract (and optionally a set of methods), the same way a regular function
  * call access key is restricted.
  *
+ * A gas function-call key must NOT carry an allowance — the protocol rejects an
+ * `AddKey` with one. The `allowance` field is therefore forced to `null`, and a
+ * non-null value (e.g. from a JS caller) is rejected with a clear error rather
+ * than silently producing an invalid permission.
+ *
  * @param numNonces - Number of independent nonce slots to allocate (1..=1024).
- * @param functionCall - The function call restriction (receiver, methods, allowance).
+ * @param functionCall - The function call restriction (receiver, methods). Any
+ *   `allowance` must be `null`/omitted.
  */
 export function gasKeyFunctionCall(
   numNonces: number,
   functionCall: FunctionCallPermissionBorsh,
 ): AccessKeyPermissionBorsh {
+  if (functionCall.allowance != null) {
+    throw new Error(
+      "Gas function-call keys must not set an allowance (rejected on-chain); pass allowance: null",
+    )
+  }
   return {
     gasKeyFunctionCall: {
       gasKeyInfo: gasKeyInfo(numNonces),
-      functionCall,
+      functionCall: { ...functionCall, allowance: null },
     },
   }
 }

--- a/packages/near-kit/src/core/actions.ts
+++ b/packages/near-kit/src/core/actions.ts
@@ -19,10 +19,14 @@ import type {
   DeployGlobalContractAction,
   DeterministicStateInitAction,
   FunctionCallAction,
+  FunctionCallPermissionBorsh,
+  GasKeyInfoBorsh,
   SignedDelegateAction,
   StakeAction,
   TransferAction,
+  TransferToGasKeyAction,
   UseGlobalContractAction,
+  WithdrawFromGasKeyAction,
 } from "./schema.js"
 import { publicKeyToZorsh, signatureToZorsh } from "./schema.js"
 import type {
@@ -208,6 +212,105 @@ export function deleteKey(publicKey: PublicKey): DeleteKeyAction {
       publicKey: publicKeyToZorsh(publicKey),
     },
   }
+}
+
+// ==================== Gas Key Actions (protocol v85 / NEAR 2.13) ====================
+
+/**
+ * Fund a gas key's prepaid balance.
+ *
+ * Gas keys are access keys that carry a prepaid balance used to pay for gas, so
+ * the account's main balance is not touched when the key signs transactions.
+ *
+ * @param publicKey - The gas key to fund.
+ * @param deposit - Amount in yoctoNEAR to add to the gas key balance.
+ */
+export function transferToGasKey(
+  publicKey: PublicKey,
+  deposit: bigint,
+): TransferToGasKeyAction {
+  return {
+    transferToGasKey: {
+      publicKey: publicKeyToZorsh(publicKey),
+      deposit,
+    },
+  }
+}
+
+/**
+ * Withdraw NEAR from a gas key's balance back to the account.
+ *
+ * @param publicKey - The gas key to withdraw from.
+ * @param amount - Amount in yoctoNEAR to move from the gas key balance to the account.
+ */
+export function withdrawFromGasKey(
+  publicKey: PublicKey,
+  amount: bigint,
+): WithdrawFromGasKeyAction {
+  return {
+    withdrawFromGasKey: {
+      publicKey: publicKeyToZorsh(publicKey),
+      amount,
+    },
+  }
+}
+
+// ==================== Gas Key Permissions (protocol v85 / NEAR 2.13) ====================
+
+/**
+ * Build a `GasKeyFullAccess` permission in Borsh format.
+ *
+ * A gas key with full access can sign any action, paying for gas from its
+ * prepaid balance. The key is added with `balance: 0`; fund it afterwards with
+ * {@link transferToGasKey}.
+ *
+ * @param numNonces - Number of independent nonce slots to allocate (1..=1024),
+ *   enabling that many transactions to be signed in parallel by this key.
+ */
+export function gasKeyFullAccess(numNonces: number): AccessKeyPermissionBorsh {
+  return {
+    gasKeyFullAccess: {
+      gasKeyInfo: gasKeyInfo(numNonces),
+    },
+  }
+}
+
+/**
+ * Build a `GasKeyFunctionCall` permission in Borsh format.
+ *
+ * Like {@link gasKeyFullAccess} but restricted to function calls on a single
+ * contract (and optionally a set of methods), the same way a regular function
+ * call access key is restricted.
+ *
+ * @param numNonces - Number of independent nonce slots to allocate (1..=1024).
+ * @param functionCall - The function call restriction (receiver, methods, allowance).
+ */
+export function gasKeyFunctionCall(
+  numNonces: number,
+  functionCall: FunctionCallPermissionBorsh,
+): AccessKeyPermissionBorsh {
+  return {
+    gasKeyFunctionCall: {
+      gasKeyInfo: gasKeyInfo(numNonces),
+      functionCall,
+    },
+  }
+}
+
+/**
+ * Construct a {@link GasKeyInfoBorsh} with a zero balance and validated nonce count.
+ *
+ * The on-chain balance starts at zero regardless of what is requested here
+ * (it is funded via {@link transferToGasKey}), so only `numNonces` is taken.
+ * @internal
+ */
+function gasKeyInfo(numNonces: number): GasKeyInfoBorsh {
+  if (!Number.isInteger(numNonces) || numNonces < 1 || numNonces > 1024) {
+    throw new Error(
+      `Gas key numNonces must be an integer in 1..=1024, got ${numNonces}`,
+    )
+  }
+  return { balance: 0n, numNonces }
 }
 
 /**

--- a/packages/near-kit/src/core/schema.ts
+++ b/packages/near-kit/src/core/schema.ts
@@ -309,9 +309,14 @@ const DeterministicStateInitSchema = b.struct({
 // ==================== Delegate Actions ====================
 
 /**
- * ClassicActions enum - same as Action but without SignedDelegate
- * Used within DelegateAction to prevent infinite recursion
- * Note: The discriminant values must match the NEAR protocol spec
+ * ClassicActions enum - the actions allowed inside a DelegateAction (NEP-366),
+ * mirroring nearcore's `NonDelegateAction` which wraps the full `Action` enum.
+ *
+ * The Borsh discriminants MUST match `Action` exactly. A zorsh enum assigns
+ * discriminants positionally, so slot 8 (`Action::Delegate`) is kept as a
+ * placeholder to keep slots 9..=13 aligned with the protocol; it is never
+ * emitted because delegate actions cannot be nested. The gas-key actions
+ * therefore land at their true discriminants 12 and 13.
  */
 const ClassicActionsSchema = b.enum({
   createAccount: CreateAccountSchema,
@@ -322,16 +327,28 @@ const ClassicActionsSchema = b.enum({
   addKey: AddKeySchema,
   deleteKey: DeleteKeySchema,
   deleteAccount: DeleteAccountSchema,
+  // Slot 8 = Action::Delegate. Placeholder for discriminant alignment only;
+  // nested delegate actions are forbidden, so this is never serialized. (An
+  // empty-struct schema is reused so this enum has no forward dependency on
+  // the delegate schemas defined below.)
+  delegatePlaceholder: CreateAccountSchema,
   deployGlobalContract: DeployGlobalContractSchema,
   useGlobalContract: UseGlobalContractSchema,
   deterministicStateInit: DeterministicStateInitSchema,
+  transferToGasKey: TransferToGasKeySchema,
+  withdrawFromGasKey: WithdrawFromGasKeySchema,
 })
 
 /**
- * ClassicAction type - actions that can be used within a DelegateAction
- * This excludes SignedDelegate to prevent infinite nesting
+ * ClassicAction type - actions that can be used within a DelegateAction.
+ *
+ * Excludes the `delegatePlaceholder` (discriminant-alignment-only) variant so
+ * callers cannot construct a nested delegate action, which the protocol forbids.
  */
-export type ClassicAction = b.infer<typeof ClassicActionsSchema>
+export type ClassicAction = Exclude<
+  b.infer<typeof ClassicActionsSchema>,
+  { delegatePlaceholder: unknown }
+>
 
 /**
  * DelegateAction for meta-transactions
@@ -534,27 +551,10 @@ export function signatureToZorsh(sig: Signature) {
  * of delegate actions (which contain nested action arrays)
  */
 function actionToZorsh(action: Action): Action {
-  // Only need to recursively process delegate actions
-  if ("signedDelegate" in action) {
-    return {
-      signedDelegate: {
-        delegateAction: {
-          senderId: action.signedDelegate.delegateAction.senderId,
-          receiverId: action.signedDelegate.delegateAction.receiverId,
-          // Recursively convert nested actions
-          actions: action.signedDelegate.delegateAction.actions.map(
-            (a: Action) => actionToZorsh(a as Action),
-          ) as ClassicAction[],
-          nonce: action.signedDelegate.delegateAction.nonce,
-          maxBlockHeight: action.signedDelegate.delegateAction.maxBlockHeight,
-          publicKey: action.signedDelegate.delegateAction.publicKey,
-        },
-        signature: action.signedDelegate.signature,
-      },
-    }
-  }
-
-  // All other actions are already in zorsh-compatible format from helpers
+  // A signed delegate's nested actions are already in zorsh-compatible form (the
+  // action factories produce them) and cannot themselves be delegate actions, so
+  // they pass through unchanged. Returning the action as-is keeps the outer
+  // delegate intact without re-walking the (differently-typed) ClassicAction set.
   return action
 }
 

--- a/packages/near-kit/src/core/schema.ts
+++ b/packages/near-kit/src/core/schema.ts
@@ -546,9 +546,12 @@ export function signatureToZorsh(sig: Signature) {
 }
 
 /**
- * Convert an action to zorsh-compatible format
- * Since action helpers now do conversion, this only handles recursive processing
- * of delegate actions (which contain nested action arrays)
+ * Identity passthrough for a transaction action.
+ *
+ * Action helpers already return zorsh-compatible shapes, and a signed delegate's
+ * nested actions cannot themselves be delegate actions, so no conversion is
+ * needed here. Retained as the `tx.actions.map(...)` hook in case per-action
+ * normalization is ever required again.
  */
 function actionToZorsh(action: Action): Action {
   // A signed delegate's nested actions are already in zorsh-compatible form (the

--- a/packages/near-kit/src/core/schema.ts
+++ b/packages/near-kit/src/core/schema.ts
@@ -93,17 +93,53 @@ const FunctionCallPermissionSchema = b.struct({
 })
 
 /**
+ * FunctionCallPermission type inferred from the Borsh schema.
+ */
+export type FunctionCallPermissionBorsh = b.infer<
+  typeof FunctionCallPermissionSchema
+>
+
+/**
  * Full access permission (empty struct)
  */
 const FullAccessPermissionSchema = b.struct({})
 
 /**
- * AccessKeyPermission enum (0 = FunctionCall, 1 = FullAccess)
+ * Gas key information (protocol v85 / NEAR 2.13).
+ *
+ * Gas keys are access keys with a prepaid balance used to pay for gas. A single
+ * gas key allocates `numNonces` independent nonce slots so it can sign multiple
+ * transactions in parallel.
+ *
+ * Field order matches nearcore `GasKeyInfo { balance: u128, num_nonces: u16 }`.
  */
-const AccessKeyPermissionSchema = b.enum({
+const GasKeyInfoSchema = b.struct({
+  balance: b.u128(),
+  numNonces: b.u16(),
+})
+
+/**
+ * AccessKeyPermission enum.
+ *
+ * Variant order is the Borsh discriminant and MUST match nearcore:
+ * 0 = FunctionCall, 1 = FullAccess, 2 = GasKeyFunctionCall, 3 = GasKeyFullAccess.
+ */
+export const AccessKeyPermissionSchema = b.enum({
   functionCall: FunctionCallPermissionSchema,
   fullAccess: FullAccessPermissionSchema,
+  gasKeyFunctionCall: b.struct({
+    gasKeyInfo: GasKeyInfoSchema,
+    functionCall: FunctionCallPermissionSchema,
+  }),
+  gasKeyFullAccess: b.struct({
+    gasKeyInfo: GasKeyInfoSchema,
+  }),
 })
+
+/**
+ * GasKeyInfo type inferred from the Borsh schema.
+ */
+export type GasKeyInfoBorsh = b.infer<typeof GasKeyInfoSchema>
 
 /**
  * AccessKeyPermission type inferred from schema
@@ -178,6 +214,31 @@ const DeleteKeySchema = b.struct({
  */
 const DeleteAccountSchema = b.struct({
   beneficiaryId: b.string(),
+})
+
+// ==================== Gas Key Actions ====================
+
+/**
+ * TransferToGasKey action (protocol v85 / NEAR 2.13).
+ *
+ * Funds a gas key's prepaid balance. Mirrors nearcore
+ * `TransferToGasKeyAction { public_key: PublicKey, deposit: u128 }`.
+ */
+const TransferToGasKeySchema = b.struct({
+  publicKey: PublicKeySchema,
+  deposit: b.u128(),
+})
+
+/**
+ * WithdrawFromGasKey action (protocol v85 / NEAR 2.13).
+ *
+ * Withdraws NEAR from a gas key's balance back to the account. Mirrors nearcore
+ * `WithdrawFromGasKeyAction { public_key: PublicKey, amount: u128 }`. Note the
+ * second field is `amount`, not `deposit`.
+ */
+const WithdrawFromGasKeySchema = b.struct({
+  publicKey: PublicKeySchema,
+  amount: b.u128(),
 })
 
 // ==================== Global Contract Actions ====================
@@ -308,6 +369,8 @@ const SignedDelegateSchema = b.struct({
  * 9 = DeployGlobalContract
  * 10 = UseGlobalContract
  * 11 = DeterministicStateInit (NEP-616)
+ * 12 = TransferToGasKey (protocol v85 / NEAR 2.13)
+ * 13 = WithdrawFromGasKey (protocol v85 / NEAR 2.13)
  */
 export const ActionSchema = b.enum({
   createAccount: CreateAccountSchema,
@@ -322,6 +385,8 @@ export const ActionSchema = b.enum({
   deployGlobalContract: DeployGlobalContractSchema,
   useGlobalContract: UseGlobalContractSchema,
   deterministicStateInit: DeterministicStateInitSchema,
+  transferToGasKey: TransferToGasKeySchema,
+  withdrawFromGasKey: WithdrawFromGasKeySchema,
 })
 
 /**
@@ -358,6 +423,12 @@ export type SignedDelegateAction = {
 }
 export type DeterministicStateInitAction = {
   deterministicStateInit: b.infer<typeof DeterministicStateInitSchema>
+}
+export type TransferToGasKeyAction = {
+  transferToGasKey: b.infer<typeof TransferToGasKeySchema>
+}
+export type WithdrawFromGasKeyAction = {
+  withdrawFromGasKey: b.infer<typeof WithdrawFromGasKeySchema>
 }
 
 // Export StateInit types for NEP-616

--- a/packages/near-kit/src/core/transaction.ts
+++ b/packages/near-kit/src/core/transaction.ts
@@ -181,6 +181,16 @@ function toAccessKeyPermissionBorsh(
         methodNames: permission.methodNames || [],
         allowance: null,
       })
+    default: {
+      // Exhaustiveness guard: every AccessKeyPermission variant is handled
+      // above. Fail fast (rather than returning undefined) if a JS caller or
+      // malformed object supplies an unknown `permission.type`.
+      const unknown = permission as { type?: unknown }
+      throw new NearError(
+        `Unknown access key permission type: ${String(unknown.type)}`,
+        "INVALID_TRANSACTION",
+      )
+    }
   }
 }
 

--- a/packages/near-kit/src/core/transaction.ts
+++ b/packages/near-kit/src/core/transaction.ts
@@ -75,7 +75,13 @@ import type {
 } from "./types.js"
 
 /**
- * User-friendly access key permission format
+ * User-friendly access key permission format.
+ *
+ * The two `gasKey*` variants add a gas key (protocol v85 / NEAR 2.13): an access
+ * key with a prepaid balance for gas and `numNonces` parallel nonce slots. The
+ * key is always added with a zero balance; fund it afterwards with
+ * {@link TransactionBuilder.transferToGasKey}. A gas function-call key cannot
+ * carry an `allowance`.
  */
 export type AccessKeyPermission =
   | { type: "fullAccess" }
@@ -84,6 +90,13 @@ export type AccessKeyPermission =
       receiverId: string
       methodNames?: string[]
       allowance?: Amount
+    }
+  | { type: "gasKeyFullAccess"; numNonces: number }
+  | {
+      type: "gasKeyFunctionCall"
+      numNonces: number
+      receiverId: string
+      methodNames?: string[]
     }
 
 type DelegateSigningOptions = {
@@ -146,18 +159,28 @@ function publicKeysEqual(a: PublicKey, b: PublicKey): boolean {
 function toAccessKeyPermissionBorsh(
   permission: AccessKeyPermission,
 ): AccessKeyPermissionBorsh {
-  if (permission.type === "fullAccess") {
-    return { fullAccess: {} }
-  } else {
-    return {
-      functionCall: {
+  switch (permission.type) {
+    case "fullAccess":
+      return { fullAccess: {} }
+    case "functionCall":
+      return {
+        functionCall: {
+          receiverId: permission.receiverId,
+          methodNames: permission.methodNames || [],
+          allowance: permission.allowance
+            ? BigInt(normalizeAmount(permission.allowance))
+            : null,
+        },
+      }
+    case "gasKeyFullAccess":
+      return actions.gasKeyFullAccess(permission.numNonces)
+    case "gasKeyFunctionCall":
+      // Gas function-call keys must not set an allowance (rejected on-chain).
+      return actions.gasKeyFunctionCall(permission.numNonces, {
         receiverId: permission.receiverId,
         methodNames: permission.methodNames || [],
-        allowance: permission.allowance
-          ? BigInt(normalizeAmount(permission.allowance))
-          : null,
-      },
-    }
+        allowance: null,
+      })
   }
 }
 
@@ -571,6 +594,55 @@ export class TransactionBuilder {
 
     if (!this.receiverId) {
       this.receiverId = accountId
+    }
+
+    return this.invalidateCache()
+  }
+
+  /**
+   * Fund a gas key's prepaid balance (protocol v85 / NEAR 2.13).
+   *
+   * The target gas key must already exist on the receiver account (add it with
+   * `.addKey(pk, { type: "gasKeyFullAccess", numNonces })`). The deposit is
+   * moved from the signer's account balance into the gas key's balance, where it
+   * is reserved to pay for gas when that key signs transactions.
+   *
+   * @param publicKey - The gas key to fund (e.g. `"ed25519:..."`).
+   * @param amount - Amount to add to the gas key balance ({@link Amount}).
+   *
+   * @remarks
+   * If no receiver has been set yet, this also sets the transaction `receiverId`
+   * to `signerId` (the account that owns the gas key).
+   */
+  transferToGasKey(publicKey: string, amount: Amount): this {
+    const amountYocto = normalizeAmount(amount)
+    const pk = parsePublicKey(publicKey)
+    this.actions.push(actions.transferToGasKey(pk, BigInt(amountYocto)))
+
+    if (!this.receiverId) {
+      this.receiverId = this.signerId
+    }
+
+    return this.invalidateCache()
+  }
+
+  /**
+   * Withdraw NEAR from a gas key's balance back to the account (protocol v85 / NEAR 2.13).
+   *
+   * @param publicKey - The gas key to withdraw from (e.g. `"ed25519:..."`).
+   * @param amount - Amount to move from the gas key balance to the account ({@link Amount}).
+   *
+   * @remarks
+   * If no receiver has been set yet, this also sets the transaction `receiverId`
+   * to `signerId` (the account that owns the gas key).
+   */
+  withdrawFromGasKey(publicKey: string, amount: Amount): this {
+    const amountYocto = normalizeAmount(amount)
+    const pk = parsePublicKey(publicKey)
+    this.actions.push(actions.withdrawFromGasKey(pk, BigInt(amountYocto)))
+
+    if (!this.receiverId) {
+      this.receiverId = this.signerId
     }
 
     return this.invalidateCache()

--- a/packages/near-kit/tests/integration/gas-key-actions.test.ts
+++ b/packages/near-kit/tests/integration/gas-key-actions.test.ts
@@ -1,18 +1,16 @@
 /**
  * Integration tests for gas-key actions and permissions (protocol v85 / NEAR 2.13).
  *
- * Proves the borsh wire format is correct by having a real 2.13 node decode and
- * admit the new actions:
+ * Proves the borsh wire format AND the RPC view schemas are correct by having a
+ * real 2.13 node execute the new actions and parsing the (status-bearing)
+ * default `.send()` response, which echoes the gas-key actions back:
  * - AddKey with a GasKeyFullAccess / GasKeyFunctionCall permission
  * - TransferToGasKey (fund the gas key) and WithdrawFromGasKey
  *
- * `send_tx` validates the borsh and runs action validation before responding, so
- * an invalid encoding is rejected synchronously (the test would throw). We send
- * with `waitUntil: "NONE"` deliberately: the status-bearing response modes echo
- * the executed actions back, and parsing the gas-key *view* representations
- * requires the RPC response/permission view schemas (owned by the keys+rpc
- * track) which are added separately. Admission alone is the wire-format proof
- * TS-2 needs; signing *with* a gas key requires TransactionV1 (TS-3).
+ * The default EXECUTED_OPTIMISTIC wait parses the response through
+ * FinalExecutionOutcomeSchema; this confirms the gas-key action/permission view
+ * schemas added in this PR parse a successful 2.13 response (the default public
+ * API path) rather than throwing.
  *
  * The sandbox version is pinned to a 2.13 release explicitly so this test does
  * not depend on the default-version bump landing first.
@@ -24,7 +22,9 @@ import { Sandbox } from "../../src/sandbox/sandbox.js"
 import { generateKey } from "../../src/utils/key.js"
 
 // Newest published 2.13 sandbox binary (stable 2.13.0 not yet released).
-const SANDBOX_VERSION = "2.13.0-rc.2"
+// Overridable via NEAR_SANDBOX_VERSION so CI can move off a renamed/GC'd RC or
+// to a stable 2.13.0 without a code change.
+const SANDBOX_VERSION = process.env.NEAR_SANDBOX_VERSION ?? "2.13.0-rc.2"
 
 describe("Gas Key Actions - Integration Tests (NEAR 2.13)", () => {
   let sandbox: Sandbox
@@ -67,9 +67,9 @@ describe("Gas Key Actions - Integration Tests (NEAR 2.13)", () => {
       keyStore: { [accountId]: accountKey.secretKey },
     })
 
-    // Add a gas key (full access, 4 parallel nonces) then fund it. The node
-    // decodes and validates both actions before responding; a bad encoding
-    // would throw here. See file header for why `waitUntil: "NONE"`.
+    // Add a gas key (full access, 4 parallel nonces) then fund it. Default
+    // (status-bearing) send: the response echoes both gas-key actions, so this
+    // also exercises the gas-key permission/action view schemas.
     const result = await accountNear
       .transaction(accountId)
       .addKey(gasKey.publicKey.toString(), {
@@ -77,9 +77,10 @@ describe("Gas Key Actions - Integration Tests (NEAR 2.13)", () => {
         numNonces: 4,
       })
       .transferToGasKey(gasKey.publicKey.toString(), "2 NEAR")
-      .send({ waitUntil: "NONE" })
+      .send()
 
-    expect(result.transaction?.hash).toBeTruthy()
+    expect("Failure" in (result.status as object)).toBe(false)
+    expect("SuccessValue" in (result.status as object)).toBe(true)
     console.log(`✓ Added + funded gas full-access key on ${accountId}`)
   }, 60000)
 
@@ -108,13 +109,14 @@ describe("Gas Key Actions - Integration Tests (NEAR 2.13)", () => {
         receiverId: "contract.near",
         methodNames: ["do_thing"],
       })
-      .send({ waitUntil: "NONE" })
+      .send()
 
-    expect(result.transaction?.hash).toBeTruthy()
+    expect("Failure" in (result.status as object)).toBe(false)
+    expect("SuccessValue" in (result.status as object)).toBe(true)
     console.log(`✓ Added gas function-call key on ${accountId}`)
   }, 60000)
 
-  test("admits add + fund + withdraw gas key actions atomically", async () => {
+  test("executes add + fund + withdraw gas key actions atomically", async () => {
     const accountId = `gaskeyw-${Date.now()}.${sandbox.rootAccount.id}`
     const accountKey = generateKey()
     const gasKey = generateKey()
@@ -133,7 +135,8 @@ describe("Gas Key Actions - Integration Tests (NEAR 2.13)", () => {
 
     // Add the gas key, fund it, then withdraw from it — all in one atomic
     // transaction so the actions execute in order without cross-tx races. This
-    // exercises the borsh encoding of all three gas-key actions in one go.
+    // exercises the borsh encoding of all three gas-key actions plus parsing
+    // their view representations in the (status-bearing) response.
     const result = await accountNear
       .transaction(accountId)
       .addKey(gasKey.publicKey.toString(), {
@@ -142,11 +145,12 @@ describe("Gas Key Actions - Integration Tests (NEAR 2.13)", () => {
       })
       .transferToGasKey(gasKey.publicKey.toString(), "2 NEAR")
       .withdrawFromGasKey(gasKey.publicKey.toString(), "1 NEAR")
-      .send({ waitUntil: "NONE" })
+      .send()
 
-    expect(result.transaction?.hash).toBeTruthy()
+    expect("Failure" in (result.status as object)).toBe(false)
+    expect("SuccessValue" in (result.status as object)).toBe(true)
     console.log(
-      `✓ Admitted add + fund + withdraw gas key actions on ${accountId}`,
+      `✓ Executed add + fund + withdraw gas key actions on ${accountId}`,
     )
   }, 60000)
 })

--- a/packages/near-kit/tests/integration/gas-key-actions.test.ts
+++ b/packages/near-kit/tests/integration/gas-key-actions.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Integration tests for gas-key actions and permissions (protocol v85 / NEAR 2.13).
+ *
+ * Proves the borsh wire format is correct by having a real 2.13 node decode and
+ * admit the new actions:
+ * - AddKey with a GasKeyFullAccess / GasKeyFunctionCall permission
+ * - TransferToGasKey (fund the gas key) and WithdrawFromGasKey
+ *
+ * `send_tx` validates the borsh and runs action validation before responding, so
+ * an invalid encoding is rejected synchronously (the test would throw). We send
+ * with `waitUntil: "NONE"` deliberately: the status-bearing response modes echo
+ * the executed actions back, and parsing the gas-key *view* representations
+ * requires the RPC response/permission view schemas (owned by the keys+rpc
+ * track) which are added separately. Admission alone is the wire-format proof
+ * TS-2 needs; signing *with* a gas key requires TransactionV1 (TS-3).
+ *
+ * The sandbox version is pinned to a 2.13 release explicitly so this test does
+ * not depend on the default-version bump landing first.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+import { Near } from "../../src/core/near.js"
+import { Sandbox } from "../../src/sandbox/sandbox.js"
+import { generateKey } from "../../src/utils/key.js"
+
+// Newest published 2.13 sandbox binary (stable 2.13.0 not yet released).
+const SANDBOX_VERSION = "2.13.0-rc.2"
+
+describe("Gas Key Actions - Integration Tests (NEAR 2.13)", () => {
+  let sandbox: Sandbox
+  let near: Near
+
+  beforeAll(async () => {
+    sandbox = await Sandbox.start({ version: SANDBOX_VERSION })
+    near = new Near({
+      network: sandbox,
+      keyStore: {
+        [sandbox.rootAccount.id]: sandbox.rootAccount.secretKey,
+      },
+    })
+    console.log(
+      `✓ Sandbox ${SANDBOX_VERSION} started: ${sandbox.rootAccount.id}`,
+    )
+  }, 180000)
+
+  afterAll(async () => {
+    if (sandbox) {
+      await sandbox.stop()
+    }
+  })
+
+  test("adds a gas full-access key and funds it via TransferToGasKey", async () => {
+    const accountId = `gaskey-${Date.now()}.${sandbox.rootAccount.id}`
+    const accountKey = generateKey()
+    const gasKey = generateKey()
+
+    // Create the account with a normal full-access key.
+    await near
+      .transaction(sandbox.rootAccount.id)
+      .createAccount(accountId)
+      .transfer(accountId, "10 NEAR")
+      .addKey(accountKey.publicKey.toString(), { type: "fullAccess" })
+      .send()
+
+    const accountNear = new Near({
+      network: sandbox,
+      keyStore: { [accountId]: accountKey.secretKey },
+    })
+
+    // Add a gas key (full access, 4 parallel nonces) then fund it. The node
+    // decodes and validates both actions before responding; a bad encoding
+    // would throw here. See file header for why `waitUntil: "NONE"`.
+    const result = await accountNear
+      .transaction(accountId)
+      .addKey(gasKey.publicKey.toString(), {
+        type: "gasKeyFullAccess",
+        numNonces: 4,
+      })
+      .transferToGasKey(gasKey.publicKey.toString(), "2 NEAR")
+      .send({ waitUntil: "NONE" })
+
+    expect(result.transaction?.hash).toBeTruthy()
+    console.log(`✓ Added + funded gas full-access key on ${accountId}`)
+  }, 60000)
+
+  test("adds a gas function-call key restricted to a contract", async () => {
+    const accountId = `gaskeyfc-${Date.now()}.${sandbox.rootAccount.id}`
+    const accountKey = generateKey()
+    const gasKey = generateKey()
+
+    await near
+      .transaction(sandbox.rootAccount.id)
+      .createAccount(accountId)
+      .transfer(accountId, "10 NEAR")
+      .addKey(accountKey.publicKey.toString(), { type: "fullAccess" })
+      .send()
+
+    const accountNear = new Near({
+      network: sandbox,
+      keyStore: { [accountId]: accountKey.secretKey },
+    })
+
+    const result = await accountNear
+      .transaction(accountId)
+      .addKey(gasKey.publicKey.toString(), {
+        type: "gasKeyFunctionCall",
+        numNonces: 2,
+        receiverId: "contract.near",
+        methodNames: ["do_thing"],
+      })
+      .send({ waitUntil: "NONE" })
+
+    expect(result.transaction?.hash).toBeTruthy()
+    console.log(`✓ Added gas function-call key on ${accountId}`)
+  }, 60000)
+
+  test("admits add + fund + withdraw gas key actions atomically", async () => {
+    const accountId = `gaskeyw-${Date.now()}.${sandbox.rootAccount.id}`
+    const accountKey = generateKey()
+    const gasKey = generateKey()
+
+    await near
+      .transaction(sandbox.rootAccount.id)
+      .createAccount(accountId)
+      .transfer(accountId, "10 NEAR")
+      .addKey(accountKey.publicKey.toString(), { type: "fullAccess" })
+      .send()
+
+    const accountNear = new Near({
+      network: sandbox,
+      keyStore: { [accountId]: accountKey.secretKey },
+    })
+
+    // Add the gas key, fund it, then withdraw from it — all in one atomic
+    // transaction so the actions execute in order without cross-tx races. This
+    // exercises the borsh encoding of all three gas-key actions in one go.
+    const result = await accountNear
+      .transaction(accountId)
+      .addKey(gasKey.publicKey.toString(), {
+        type: "gasKeyFullAccess",
+        numNonces: 1,
+      })
+      .transferToGasKey(gasKey.publicKey.toString(), "2 NEAR")
+      .withdrawFromGasKey(gasKey.publicKey.toString(), "1 NEAR")
+      .send({ waitUntil: "NONE" })
+
+    expect(result.transaction?.hash).toBeTruthy()
+    console.log(
+      `✓ Admitted add + fund + withdraw gas key actions on ${accountId}`,
+    )
+  }, 60000)
+})

--- a/packages/near-kit/tests/unit/gas-key.test.ts
+++ b/packages/near-kit/tests/unit/gas-key.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for gas-key actions and access-key permissions (protocol v85 / NEAR 2.13).
+ *
+ * Wire-format facts (from nearcore):
+ * - Action discriminants: TransferToGasKey = 12, WithdrawFromGasKey = 13.
+ * - AccessKeyPermission discriminants: FunctionCall = 0, FullAccess = 1,
+ *   GasKeyFunctionCall = 2, GasKeyFullAccess = 3.
+ * - GasKeyInfo { balance: u128, num_nonces: u16 }.
+ */
+
+import { describe, expect, test } from "vitest"
+import {
+  gasKeyFullAccess,
+  gasKeyFunctionCall,
+  transferToGasKey,
+  withdrawFromGasKey,
+} from "../../src/core/actions.js"
+import {
+  AccessKeyPermissionSchema,
+  ActionSchema,
+} from "../../src/core/schema.js"
+import { type Ed25519PublicKey, KeyType } from "../../src/core/types.js"
+
+const ed25519Pk = (fill: number): Ed25519PublicKey => ({
+  keyType: KeyType.ED25519,
+  data: new Uint8Array(32).fill(fill),
+  toString: () => "ed25519:test",
+})
+
+describe("Gas key actions", () => {
+  test("transferToGasKey has shape and discriminant 12", () => {
+    const action = transferToGasKey(ed25519Pk(1), 5n)
+
+    expect("transferToGasKey" in action).toBe(true)
+    expect(action.transferToGasKey.deposit).toBe(5n)
+    expect(action.transferToGasKey.publicKey.ed25519Key.data).toEqual(
+      Array(32).fill(1),
+    )
+
+    const bytes = ActionSchema.serialize(action)
+    expect(bytes[0]).toBe(12)
+    // discriminant(1) + pubkey enum tag(1) + 32 key bytes + u128 deposit(16)
+    expect(bytes.length).toBe(1 + 1 + 32 + 16)
+  })
+
+  test("withdrawFromGasKey has shape and discriminant 13", () => {
+    const action = withdrawFromGasKey(ed25519Pk(2), 7n)
+
+    expect("withdrawFromGasKey" in action).toBe(true)
+    // Second field is `amount`, not `deposit`.
+    expect(action.withdrawFromGasKey.amount).toBe(7n)
+    expect(action.withdrawFromGasKey.publicKey.ed25519Key.data).toEqual(
+      Array(32).fill(2),
+    )
+
+    const bytes = ActionSchema.serialize(action)
+    expect(bytes[0]).toBe(13)
+    expect(bytes.length).toBe(1 + 1 + 32 + 16)
+  })
+
+  test("gas key actions round-trip through ActionSchema", () => {
+    for (const action of [
+      transferToGasKey(ed25519Pk(3), 1_000_000n),
+      withdrawFromGasKey(ed25519Pk(4), 2_000_000n),
+    ]) {
+      const bytes = ActionSchema.serialize(action)
+      expect(ActionSchema.deserialize(bytes)).toEqual(action)
+    }
+  })
+})
+
+describe("Gas key permissions", () => {
+  test("gasKeyFullAccess has discriminant 3 and zero balance", () => {
+    const permission = gasKeyFullAccess(4)
+
+    expect("gasKeyFullAccess" in permission).toBe(true)
+    if (!("gasKeyFullAccess" in permission)) throw new Error("unreachable")
+    expect(permission.gasKeyFullAccess.gasKeyInfo.balance).toBe(0n)
+    expect(permission.gasKeyFullAccess.gasKeyInfo.numNonces).toBe(4)
+
+    const bytes = AccessKeyPermissionSchema.serialize(permission)
+    expect(bytes[0]).toBe(3)
+    // discriminant(1) + balance u128(16) + num_nonces u16(2)
+    expect(bytes.length).toBe(1 + 16 + 2)
+  })
+
+  test("GasKeyFullAccess matches the exact nearcore borsh wire bytes", () => {
+    // GasKeyFullAccess(GasKeyInfo { balance: 0, num_nonces: 5 })
+    // borsh: [03] ++ u128(0) LE (16 bytes) ++ u16(5) LE (2 bytes)
+    const bytes = AccessKeyPermissionSchema.serialize(gasKeyFullAccess(5))
+    const expected = new Uint8Array([
+      3, // GasKeyFullAccess discriminant
+      ...new Array(16).fill(0), // balance u128 = 0
+      5,
+      0, // num_nonces u16 = 5 (little-endian)
+    ])
+    expect(bytes).toEqual(expected)
+  })
+
+  test("gasKeyFunctionCall has discriminant 2 and no allowance", () => {
+    const permission = gasKeyFunctionCall(2, {
+      receiverId: "contract.near",
+      methodNames: ["do_thing"],
+      allowance: null,
+    })
+
+    expect("gasKeyFunctionCall" in permission).toBe(true)
+    if (!("gasKeyFunctionCall" in permission)) throw new Error("unreachable")
+    expect(permission.gasKeyFunctionCall.gasKeyInfo.balance).toBe(0n)
+    expect(permission.gasKeyFunctionCall.gasKeyInfo.numNonces).toBe(2)
+    expect(permission.gasKeyFunctionCall.functionCall.allowance).toBe(null)
+    expect(permission.gasKeyFunctionCall.functionCall.receiverId).toBe(
+      "contract.near",
+    )
+
+    const bytes = AccessKeyPermissionSchema.serialize(permission)
+    expect(bytes[0]).toBe(2)
+  })
+
+  test("gas key permissions round-trip through AccessKeyPermissionSchema", () => {
+    for (const permission of [
+      gasKeyFullAccess(1),
+      gasKeyFunctionCall(1024, {
+        receiverId: "c.near",
+        methodNames: [],
+        allowance: null,
+      }),
+    ]) {
+      const bytes = AccessKeyPermissionSchema.serialize(permission)
+      expect(AccessKeyPermissionSchema.deserialize(bytes)).toEqual(permission)
+    }
+  })
+
+  test("numNonces is validated against the 1..=1024 protocol bound", () => {
+    expect(() => gasKeyFullAccess(0)).toThrow(/1\.\.=1024/)
+    expect(() => gasKeyFullAccess(1025)).toThrow(/1\.\.=1024/)
+    expect(() => gasKeyFullAccess(1.5)).toThrow(/1\.\.=1024/)
+    expect(() => gasKeyFullAccess(1)).not.toThrow()
+    expect(() => gasKeyFullAccess(1024)).not.toThrow()
+  })
+})

--- a/packages/near-kit/tests/unit/gas-key.test.ts
+++ b/packages/near-kit/tests/unit/gas-key.test.ts
@@ -117,6 +117,16 @@ describe("Gas key permissions", () => {
     expect(bytes[0]).toBe(2)
   })
 
+  test("gasKeyFunctionCall rejects a non-null allowance", () => {
+    expect(() =>
+      gasKeyFunctionCall(2, {
+        receiverId: "contract.near",
+        methodNames: [],
+        allowance: 100n,
+      }),
+    ).toThrow(/allowance/)
+  })
+
   test("gas key permissions round-trip through AccessKeyPermissionSchema", () => {
     for (const permission of [
       gasKeyFullAccess(1),

--- a/packages/near-kit/tests/unit/rpc-schemas.test.ts
+++ b/packages/near-kit/tests/unit/rpc-schemas.test.ts
@@ -3,7 +3,11 @@
  */
 
 import { describe, expect, test } from "vitest"
-import { TransactionSchema } from "../../src/core/rpc/rpc-schemas.js"
+import {
+  AccessKeyPermissionSchema,
+  ActionSchema,
+  TransactionSchema,
+} from "../../src/core/rpc/rpc-schemas.js"
 
 const baseTransaction = {
   signer_id: "alice.near",
@@ -58,5 +62,94 @@ describe("TransactionSchema", () => {
         }),
       ).toThrow()
     })
+  })
+})
+
+describe("Gas key RPC views (NEAR 2.13)", () => {
+  describe("AccessKeyPermissionSchema", () => {
+    test("parses GasKeyFullAccess view", () => {
+      const parsed = AccessKeyPermissionSchema.parse({
+        GasKeyFullAccess: {
+          balance: "5000000000000000000000000",
+          num_nonces: 4,
+        },
+      })
+      expect(parsed).toEqual({
+        GasKeyFullAccess: {
+          balance: "5000000000000000000000000",
+          num_nonces: 4,
+        },
+      })
+    })
+
+    test("parses GasKeyFunctionCall view (gas-key info + function-call fields)", () => {
+      const view = {
+        GasKeyFunctionCall: {
+          balance: "0",
+          num_nonces: 2,
+          allowance: null,
+          receiver_id: "contract.near",
+          method_names: ["do_thing"],
+        },
+      }
+      expect(AccessKeyPermissionSchema.parse(view)).toEqual(view)
+    })
+
+    test("still parses FullAccess and FunctionCall views", () => {
+      expect(AccessKeyPermissionSchema.parse("FullAccess")).toBe("FullAccess")
+      const fc = {
+        FunctionCall: {
+          receiver_id: "c.near",
+          method_names: [],
+          allowance: null,
+        },
+      }
+      expect(AccessKeyPermissionSchema.parse(fc)).toEqual(fc)
+    })
+  })
+
+  describe("response ActionSchema", () => {
+    test("parses a TransferToGasKey action view", () => {
+      const view = {
+        TransferToGasKey: {
+          public_key: "ed25519:8nFkHgRePSGD9UsK3Hx6nWKXGQ7Kd7k3k7k3k7k3k7k3",
+          deposit: "2000000000000000000000000",
+        },
+      }
+      expect(ActionSchema.parse(view)).toEqual(view)
+    })
+
+    test("parses a WithdrawFromGasKey action view (amount, not deposit)", () => {
+      const view = {
+        WithdrawFromGasKey: {
+          public_key: "ed25519:8nFkHgRePSGD9UsK3Hx6nWKXGQ7Kd7k3k7k3k7k3k7k3",
+          amount: "1000000000000000000000000",
+        },
+      }
+      expect(ActionSchema.parse(view)).toEqual(view)
+    })
+  })
+
+  test("a transaction echoing gas-key actions parses (regression for default send)", () => {
+    // Codex P1: a successful 2.13 EXECUTED_OPTIMISTIC response echoes these
+    // actions; the default .send() path must parse them, not throw.
+    const parsed = TransactionSchema.parse({
+      ...baseTransaction,
+      actions: [
+        {
+          TransferToGasKey: {
+            public_key: "ed25519:8nFkHgRePSGD9UsK3Hx6nWKXGQ7Kd7k3k7k3k7k3k7k3",
+            deposit: "2000000000000000000000000",
+          },
+        },
+        {
+          WithdrawFromGasKey: {
+            public_key: "ed25519:8nFkHgRePSGD9UsK3Hx6nWKXGQ7Kd7k3k7k3k7k3k7k3",
+            amount: "1000000000000000000000000",
+          },
+        },
+      ],
+    })
+    expect(parsed.actions).toHaveLength(2)
   })
 })

--- a/packages/near-kit/tests/unit/transaction-builder.test.ts
+++ b/packages/near-kit/tests/unit/transaction-builder.test.ts
@@ -510,6 +510,86 @@ describe("TransactionBuilder - Edge Cases", () => {
   })
 })
 
+describe("TransactionBuilder - Gas Keys (NEAR 2.13)", () => {
+  test("should chain transferToGasKey action and default receiver to signer", () => {
+    const builder = createBuilder().transferToGasKey(
+      TEST_PUBLIC_KEY,
+      Amount.NEAR(1),
+    )
+
+    // @ts-expect-error - accessing private field for testing
+    expect(builder.actions.length).toBe(1)
+    // @ts-expect-error - accessing private field for testing
+    expect(builder.actions[0].transferToGasKey).toBeDefined()
+    // @ts-expect-error - accessing private field for testing
+    expect(builder.actions[0].transferToGasKey.deposit).toBe(
+      1000000000000000000000000n,
+    )
+    // @ts-expect-error - accessing private field for testing
+    expect(builder.receiverId).toBe("alice.near")
+  })
+
+  test("should chain withdrawFromGasKey action", () => {
+    const builder = createBuilder().withdrawFromGasKey(
+      TEST_PUBLIC_KEY,
+      "2 NEAR",
+    )
+
+    // @ts-expect-error - accessing private field for testing
+    expect(builder.actions.length).toBe(1)
+    // @ts-expect-error - accessing private field for testing
+    expect(builder.actions[0].withdrawFromGasKey).toBeDefined()
+    // @ts-expect-error - accessing private field for testing
+    expect(builder.actions[0].withdrawFromGasKey.amount).toBe(
+      2000000000000000000000000n,
+    )
+  })
+
+  test("addKey with gasKeyFullAccess permission builds disc-3 permission", () => {
+    const builder = createBuilder().addKey(TEST_PUBLIC_KEY, {
+      type: "gasKeyFullAccess",
+      numNonces: 8,
+    })
+
+    // @ts-expect-error - accessing private field for testing
+    const action = builder.actions[0].addKey
+    expect(action.accessKey.permission.gasKeyFullAccess).toBeDefined()
+    expect(
+      action.accessKey.permission.gasKeyFullAccess.gasKeyInfo.balance,
+    ).toBe(0n)
+    expect(
+      action.accessKey.permission.gasKeyFullAccess.gasKeyInfo.numNonces,
+    ).toBe(8)
+  })
+
+  test("addKey with gasKeyFunctionCall permission omits allowance", () => {
+    const builder = createBuilder().addKey(TEST_PUBLIC_KEY, {
+      type: "gasKeyFunctionCall",
+      numNonces: 3,
+      receiverId: "contract.near",
+      methodNames: ["m1", "m2"],
+    })
+
+    // @ts-expect-error - accessing private field for testing
+    const action = builder.actions[0].addKey
+    const perm = action.accessKey.permission.gasKeyFunctionCall
+    expect(perm).toBeDefined()
+    expect(perm.gasKeyInfo.numNonces).toBe(3)
+    expect(perm.functionCall.allowance).toBe(null)
+    expect(perm.functionCall.receiverId).toBe("contract.near")
+    expect(perm.functionCall.methodNames).toEqual(["m1", "m2"])
+  })
+
+  test("rejects an out-of-range gas key nonce count", () => {
+    expect(() =>
+      createBuilder().addKey(TEST_PUBLIC_KEY, {
+        type: "gasKeyFullAccess",
+        numNonces: 0,
+      }),
+    ).toThrow(/1\.\.=1024/)
+  })
+})
+
 describe("TransactionBuilder - NEP-616 StateInit", () => {
   test("should chain stateInit action with account ID reference", () => {
     const builder = createBuilder().stateInit({

--- a/packages/near-kit/tests/unit/transaction-builder.test.ts
+++ b/packages/near-kit/tests/unit/transaction-builder.test.ts
@@ -588,6 +588,16 @@ describe("TransactionBuilder - Gas Keys (NEAR 2.13)", () => {
       }),
     ).toThrow(/1\.\.=1024/)
   })
+
+  test("rejects an unknown access key permission type (JS callers)", () => {
+    expect(() =>
+      createBuilder().addKey(TEST_PUBLIC_KEY, {
+        // Simulate a malformed permission from an untyped JS caller.
+        type: "bogusPermission",
+        // biome-ignore lint/suspicious/noExplicitAny: testing runtime guard
+      } as any),
+    ).toThrow(/Unknown access key permission type/)
+  })
 })
 
 describe("TransactionBuilder - NEP-616 StateInit", () => {


### PR DESCRIPTION
## Summary

NEAR 2.13 / protocol v85 adds gas keys (access keys with a prepaid gas balance and parallel nonce slots). This catches the TS library up to near-kit-rs.

- `TransferToGasKey` (borsh disc 12) and `WithdrawFromGasKey` (13) actions + `.transferToGasKey()` / `.withdrawFromGasKey()` builder methods.
- `GasKeyFunctionCall` (2) and `GasKeyFullAccess` (3) access-key permissions + `GasKeyInfo { balance: u128, num_nonces: u16 }`, via `.addKey(pk, { type: "gasKeyFullAccess", numNonces })` / `{ type: "gasKeyFunctionCall", numNonces, receiverId, methodNames }`. `numNonces` is validated to `1..=1024` with a zero balance, matching nearcore action validation.

All additive: existing V0 transactions, actions, and permissions are unchanged. Signing *with* a gas key needs TransactionV1 and is a follow-up.

## Test plan

- [x] Unit: exact borsh bytes, discriminants, and round-trips for the new actions/permissions; builder coverage.
- [x] Integration: a `2.13.0-rc.2` sandbox decodes and admits add/fund/withdraw gas-key transactions (wire-format confirmed on-chain).
- [x] build + typecheck + lint + `test:unit` pass.