### PR TITLE
feat(transaction): gas-key transacting + strict nonce (NEAR 2.13)

### DIFF
--- a/.changeset/gas-key-transacting.md
+++ b/.changeset/gas-key-transacting.md
@@ -1,0 +1,9 @@
+---
+"near-kit": minor
+---
+
+Add gas-key transacting and strict nonce mode (NEAR 2.13 / protocol v85)
+
+- Versioned transaction (V1) borsh encoding: `TransactionNonce` (`Nonce` / `GasKeyNonce`), `NonceMode` (`Monotonic` / `Strict`), and the custom `[0x01]`-tag scheme. V0 transactions stay tag-less and remain the default, so existing transactions are unchanged.
+- `.useGasKey(nonceIndex)` on the transaction builder signs with a gas key, carrying a `GasKeyNonce` and fetching the per-slot nonce via `EXPERIMENTAL_view_gas_key_nonces`.
+- `.strictNonceMode()` opts into strict (`ak_nonce + 1`) nonce validation.

--- a/packages/near-kit/src/core/schema.ts
+++ b/packages/near-kit/src/core/schema.ts
@@ -499,6 +499,67 @@ export const SignedTransactionSchema = b.struct({
   signature: SignatureSchema,
 })
 
+// ==================== Transaction V1 (gas keys / strict nonce, NEAR 2.13) ====================
+
+/**
+ * Tag byte prepended to a V1 transaction on the wire.
+ *
+ * NEAR 2.13 makes `Transaction` a versioned enum but keeps custom borsh for
+ * backward compatibility: a V0 transaction is serialized TAG-LESS (exactly the
+ * legacy unversioned struct), while a V1 transaction is serialized as
+ * `[0x01] ++ borsh(TransactionV1)`. The deserializer distinguishes them by the
+ * second byte (the high byte of the leading AccountId length, always 0 for V0).
+ * @internal
+ */
+const TRANSACTION_V1_TAG = 1
+
+/**
+ * TransactionNonce enum (NEAR 2.13).
+ *
+ * Variant order is the Borsh discriminant and MUST match nearcore:
+ * 0 = `Nonce { nonce: u64 }` (ordinary access keys),
+ * 1 = `GasKeyNonce { nonce: u64, nonce_index: u16 }` (gas keys).
+ */
+export const TransactionNonceSchema = b.enum({
+  nonce: b.struct({ nonce: b.u64() }),
+  gasKeyNonce: b.struct({ nonce: b.u64(), nonceIndex: b.u16() }),
+})
+
+/**
+ * NonceMode enum (NEAR 2.13).
+ *
+ * Variant order is the Borsh discriminant and MUST match nearcore:
+ * 0 = `Monotonic` (default; any nonce strictly greater than the access key
+ * nonce), 1 = `Strict` (nonce must be exactly `ak_nonce + 1`).
+ */
+export const NonceModeSchema = b.enum({
+  monotonic: b.struct({}),
+  strict: b.struct({}),
+})
+
+/**
+ * TransactionV1 schema (NEAR 2.13).
+ *
+ * Same shape as V0 but the `nonce` is a {@link TransactionNonceSchema} and a
+ * trailing `nonceMode` is appended. Field order matches nearcore `TransactionV1`:
+ * signer_id, public_key, nonce, receiver_id, block_hash, actions, nonce_mode.
+ *
+ * This serializes the struct ALONE (no version tag); use
+ * {@link serializeTransactionV1} to get the tagged wire bytes.
+ */
+export const TransactionV1Schema = b.struct({
+  signerId: b.string(),
+  publicKey: PublicKeySchema,
+  nonce: TransactionNonceSchema,
+  receiverId: b.string(),
+  blockHash: b.array(b.u8(), 32),
+  actions: b.vec(ActionSchema),
+  nonceMode: NonceModeSchema,
+})
+
+export type TransactionNonceBorsh = b.infer<typeof TransactionNonceSchema>
+export type NonceModeBorsh = b.infer<typeof NonceModeSchema>
+
 // ==================== Serialization Helpers ====================
 
 /**
@@ -632,6 +693,75 @@ export function serializeSignedTransaction(
     },
     signature: signatureToZorsh(signedTx.signature),
   })
+}
+
+// ==================== Transaction V1 Serialization (NEAR 2.13) ====================
+
+/**
+ * The V1 fields of a transaction, mirroring nearcore `TransactionV1`.
+ *
+ * `nonce` is a {@link TransactionNonceBorsh} (carries a nonce index for gas
+ * keys) and `nonceMode` controls validation. The remaining fields match the
+ * ordinary {@link Transaction}.
+ */
+export interface TransactionV1 {
+  signerId: string
+  publicKey: PublicKey
+  nonce: TransactionNonceBorsh
+  receiverId: string
+  blockHash: Uint8Array
+  actions: Action[]
+  nonceMode: NonceModeBorsh
+}
+
+/**
+ * Prepend the V1 version tag to already-serialized V1 struct bytes.
+ * @internal
+ */
+function withV1Tag(structBytes: Uint8Array): Uint8Array {
+  const out = new Uint8Array(structBytes.length + 1)
+  out[0] = TRANSACTION_V1_TAG
+  out.set(structBytes, 1)
+  return out
+}
+
+/**
+ * Serialize a V1 transaction to wire bytes (`[0x01] ++ borsh(TransactionV1)`).
+ *
+ * Use this for the signing payload of a gas-key or strict-nonce transaction. A
+ * V0 transaction stays tag-less via {@link serializeTransaction}; never write a
+ * `0x00` tag for V0 (that would break backward compatibility).
+ */
+export function serializeTransactionV1(tx: TransactionV1): Uint8Array {
+  const struct = TransactionV1Schema.serialize({
+    signerId: tx.signerId,
+    publicKey: publicKeyToZorsh(tx.publicKey),
+    nonce: tx.nonce,
+    receiverId: tx.receiverId,
+    blockHash: Array.from(tx.blockHash),
+    actions: tx.actions.map(actionToZorsh),
+    nonceMode: tx.nonceMode,
+  })
+  return withV1Tag(struct)
+}
+
+/**
+ * Serialize a signed V1 transaction to wire bytes.
+ *
+ * The encoding is `[0x01] ++ borsh(TransactionV1) ++ borsh(Signature)`: the
+ * version tag belongs to the inner `Transaction`, and the signature follows the
+ * (tagged) transaction, matching nearcore's `SignedTransaction` borsh.
+ */
+export function serializeSignedTransactionV1(
+  tx: TransactionV1,
+  signature: Signature,
+): Uint8Array {
+  const txBytes = serializeTransactionV1(tx)
+  const sigBytes = SignatureSchema.serialize(signatureToZorsh(signature))
+  const out = new Uint8Array(txBytes.length + sigBytes.length)
+  out.set(txBytes, 0)
+  out.set(sigBytes, txBytes.length)
+  return out
 }
 
 // ==================== Delegate Action Serialization ====================

--- a/packages/near-kit/src/core/transaction.ts
+++ b/packages/near-kit/src/core/transaction.ts
@@ -58,7 +58,11 @@ import {
   type SignedDelegateAction,
   serializeDelegateAction,
   serializeSignedTransaction,
+  serializeSignedTransactionV1,
   serializeTransaction,
+  serializeTransactionV1,
+  type TransactionNonceBorsh,
+  type TransactionV1,
 } from "./schema.js"
 import type {
   Action,
@@ -218,7 +222,24 @@ export class TransactionBuilder {
   private cachedSignedTx?: {
     signedTx: SignedTransaction
     hash: string
+    /**
+     * Pre-serialized signed-transaction wire bytes. Set only for V1
+     * (gas-key / strict-nonce) transactions, whose custom `[0x01]`-tagged
+     * encoding is not expressible via the V0 {@link SignedTransaction} shape.
+     * When present, `serialize()` / `send()` use these bytes directly.
+     */
+    serialized?: Uint8Array
   }
+  /**
+   * Gas-key nonce index for this transaction. When set, the builder signs a V1
+   * transaction whose nonce is a `GasKeyNonce { nonce, nonceIndex }`.
+   */
+  private gasKeyNonceIndex?: number
+  /**
+   * Opt into strict nonce mode (`nonce === ak_nonce + 1`). Forces a V1
+   * transaction even for an ordinary access key.
+   */
+  private strictNonce = false
 
   constructor(
     signerId: string,
@@ -875,6 +896,67 @@ export class TransactionBuilder {
   }
 
   /**
+   * Sign this transaction with a gas key (protocol v85 / NEAR 2.13).
+   *
+   * Gas keys carry a prepaid gas balance and allocate several independent nonce
+   * slots so they can sign transactions in parallel. This selects the nonce
+   * slot (`nonceIndex`) to use and switches the builder to the versioned
+   * transaction (V1) encoding required to carry a gas-key nonce.
+   *
+   * The nonce for the chosen slot is fetched and managed independently per
+   * `(account, public key, nonce index)`, so concurrent transactions on
+   * different indexes of the same gas key do not collide.
+   *
+   * @param nonceIndex - Which gas-key nonce slot to use (`0..numNonces`).
+   *
+   * @example
+   * ```typescript
+   * await near.transaction("alice.near")
+   *   .signWith(gasKeyPrivateKey)
+   *   .useGasKey(0)
+   *   .functionCall("contract.near", "method", {})
+   *   .send()
+   * ```
+   *
+   * @remarks Combine with {@link signWith} to use the gas key's private key.
+   */
+  useGasKey(nonceIndex: number): this {
+    if (!Number.isInteger(nonceIndex) || nonceIndex < 0 || nonceIndex > 65535) {
+      throw new NearError(
+        `Gas key nonceIndex must be an integer in 0..=65535, got ${nonceIndex}`,
+        "INVALID_TRANSACTION",
+      )
+    }
+    this.gasKeyNonceIndex = nonceIndex
+    return this.invalidateCache()
+  }
+
+  /**
+   * Opt into strict nonce mode (protocol v85 / NEAR 2.13).
+   *
+   * In strict mode the transaction nonce must be exactly `ak_nonce + 1`,
+   * enforcing sequential ordering, instead of the default monotonic rule (any
+   * nonce strictly greater than the access key nonce). This switches the builder
+   * to the versioned transaction (V1) encoding.
+   *
+   * @param strict - Whether to enable strict mode (defaults to `true`).
+   */
+  strictNonceMode(strict = true): this {
+    this.strictNonce = strict
+    return this.invalidateCache()
+  }
+
+  /**
+   * Whether this transaction must be encoded as a versioned (V1) transaction.
+   * V1 is required to carry a gas-key nonce or to request strict nonce mode;
+   * an ordinary transaction stays V0 (tag-less) for backward compatibility.
+   * @internal
+   */
+  private requiresV1(): boolean {
+    return this.gasKeyNonceIndex !== undefined || this.strictNonce
+  }
+
+  /**
    * Build the unsigned transaction
    */
   async build(): Promise<Transaction> {
@@ -961,6 +1043,12 @@ export class TransactionBuilder {
       )
     }
 
+    // Gas-key or strict-nonce transactions use the versioned (V1) encoding.
+    if (this.requiresV1()) {
+      this.cachedSignedTx = await this.signV1()
+      return this
+    }
+
     // Build the transaction
     const transaction = await this.build()
 
@@ -992,6 +1080,140 @@ export class TransactionBuilder {
     }
 
     return this
+  }
+
+  /**
+   * Build and sign a versioned (V1) transaction for the gas-key / strict-nonce
+   * path. Produces the cache entry consumed by {@link sign}, including the
+   * pre-serialized `[0x01]`-tagged signed bytes.
+   * @internal
+   */
+  private async signV1(): Promise<{
+    signedTx: SignedTransaction
+    hash: string
+    serialized: Uint8Array
+  }> {
+    if (!this.receiverId) {
+      throw new NearError(
+        "No receiver ID set for transaction",
+        "INVALID_TRANSACTION",
+      )
+    }
+
+    const keyPair = await this.resolveKeyPair()
+    const publicKey = keyPair.publicKey
+    const txNonce = await this.resolveV1Nonce(publicKey)
+
+    const block = await this.rpc.getBlock({ finality: "final" })
+    const blockHash = base58.decode(block.header.hash)
+
+    const v1: TransactionV1 = {
+      signerId: this.signerId,
+      publicKey,
+      nonce: txNonce,
+      receiverId: this.receiverId,
+      blockHash,
+      actions: this.actions,
+      nonceMode: this.strictNonce ? { strict: {} } : { monotonic: {} },
+    }
+
+    const serializedTx = serializeTransactionV1(v1)
+    const messageHash = new Uint8Array(
+      await crypto.subtle.digest(
+        "SHA-256",
+        serializedTx as Uint8Array<ArrayBuffer>,
+      ),
+    )
+    const txHash = base58.encode(messageHash)
+
+    const signature = this.signer
+      ? await this.signer(messageHash)
+      : keyPair.sign(messageHash)
+
+    // Underlying u64 nonce, regardless of the V1 nonce variant.
+    const nonceValue =
+      "gasKeyNonce" in txNonce ? txNonce.gasKeyNonce.nonce : txNonce.nonce.nonce
+
+    return {
+      // A V0-shaped SignedTransaction is kept for hash/field access by callers;
+      // the wire bytes come from `serialized` (the V1 encoding can't round-trip
+      // through the V0 SignedTransaction type).
+      signedTx: {
+        transaction: {
+          signerId: this.signerId,
+          publicKey,
+          nonce: nonceValue,
+          receiverId: this.receiverId,
+          actions: this.actions,
+          blockHash,
+        },
+        signature,
+      },
+      hash: txHash,
+      serialized: serializeSignedTransactionV1(v1, signature),
+    }
+  }
+
+  /**
+   * Resolve the {@link TransactionNonceBorsh} for a V1 transaction.
+   *
+   * For a gas key the nonce comes from the chosen nonce slot (queried via
+   * `EXPERIMENTAL_view_gas_key_nonces`) and is wrapped as `GasKeyNonce`; each
+   * slot is tracked independently so parallel transactions on different slots
+   * don't collide. For a strict-nonce ordinary key it's a plain `Nonce`.
+   * @internal
+   */
+  private async resolveV1Nonce(
+    publicKey: PublicKey,
+  ): Promise<TransactionNonceBorsh> {
+    const pkString = publicKey.toString()
+
+    if (this.gasKeyNonceIndex !== undefined) {
+      const index = this.gasKeyNonceIndex
+      const nonce = await TransactionBuilder.nonceManager.getNextNonce(
+        this.signerId,
+        `${pkString}#${index}`,
+        async () => this.fetchGasKeyNonce(pkString, index),
+      )
+      return { gasKeyNonce: { nonce, nonceIndex: index } }
+    }
+
+    const nonce = await TransactionBuilder.nonceManager.getNextNonce(
+      this.signerId,
+      pkString,
+      async () => {
+        const accessKey = await this.rpc.getAccessKey(this.signerId, pkString)
+        return BigInt(accessKey.nonce)
+      },
+    )
+    return { nonce: { nonce } }
+  }
+
+  /**
+   * Fetch the current on-chain nonce for a gas key's nonce slot via
+   * `EXPERIMENTAL_view_gas_key_nonces`, which returns one nonce per slot.
+   * @internal
+   */
+  private async fetchGasKeyNonce(
+    publicKey: string,
+    nonceIndex: number,
+  ): Promise<bigint> {
+    const result = await this.rpc.call<{ nonces?: unknown }>(
+      "EXPERIMENTAL_view_gas_key_nonces",
+      {
+        finality: "optimistic",
+        account_id: this.signerId,
+        public_key: publicKey,
+      },
+    )
+    const nonces = result?.nonces
+    if (!Array.isArray(nonces) || nonceIndex >= nonces.length) {
+      throw new NearError(
+        `Gas key ${publicKey} on ${this.signerId} has no nonce slot ${nonceIndex}`,
+        "INVALID_TRANSACTION",
+      )
+    }
+    return BigInt(nonces[nonceIndex] as number | string)
   }
 
   /**
@@ -1040,7 +1262,11 @@ export class TransactionBuilder {
         "INVALID_STATE",
       )
     }
-    return serializeSignedTransaction(this.cachedSignedTx.signedTx)
+    // V1 (gas-key / strict-nonce) transactions carry pre-serialized wire bytes.
+    return (
+      this.cachedSignedTx.serialized ??
+      serializeSignedTransaction(this.cachedSignedTx.signedTx)
+    )
   }
 
   /**
@@ -1122,10 +1348,12 @@ export class TransactionBuilder {
           )
         }
 
-        const { signedTx, hash } = this.cachedSignedTx
+        const { signedTx, hash, serialized } = this.cachedSignedTx
 
-        // Serialize signed transaction using Borsh
-        const signedSerialized = serializeSignedTransaction(signedTx)
+        // Serialize signed transaction using Borsh. V1 (gas-key / strict-nonce)
+        // transactions carry pre-serialized wire bytes from signV1().
+        const signedSerialized =
+          serialized ?? serializeSignedTransaction(signedTx)
 
         // Send to network
         const result = await this.rpc.sendTransaction(

--- a/packages/near-kit/src/core/transaction.ts
+++ b/packages/near-kit/src/core/transaction.ts
@@ -907,7 +907,9 @@ export class TransactionBuilder {
    * `(account, public key, nonce index)`, so concurrent transactions on
    * different indexes of the same gas key do not collide.
    *
-   * @param nonceIndex - Which gas-key nonce slot to use (`0..numNonces`).
+   * @param nonceIndex - Which gas-key nonce slot to use. Slots are 0-based, so
+   *   valid values are `0` to `numNonces - 1` (the slot count the key was added
+   *   with). An out-of-range slot is rejected when the nonce is fetched.
    *
    * @example
    * ```typescript
@@ -1170,12 +1172,27 @@ export class TransactionBuilder {
 
     if (this.gasKeyNonceIndex !== undefined) {
       const index = this.gasKeyNonceIndex
+      // Strict mode bypasses the monotonic cache (see below); otherwise reserve
+      // the per-slot nonce through the shared manager so parallel transactions
+      // on the same slot don't collide.
+      if (this.strictNonce) {
+        const nonce = (await this.fetchGasKeyNonce(pkString, index)) + 1n
+        return { gasKeyNonce: { nonce, nonceIndex: index } }
+      }
       const nonce = await TransactionBuilder.nonceManager.getNextNonce(
         this.signerId,
         `${pkString}#${index}`,
         async () => this.fetchGasKeyNonce(pkString, index),
       )
       return { gasKeyNonce: { nonce, nonceIndex: index } }
+    }
+
+    // Strict mode requires the nonce to be EXACTLY ak_nonce + 1, so it must not
+    // go through the monotonic NonceManager (whose cache can be ahead of chain
+    // and hand out ak_nonce + 2+). Fetch the chain nonce directly instead.
+    if (this.strictNonce) {
+      const accessKey = await this.rpc.getAccessKey(this.signerId, pkString)
+      return { nonce: { nonce: BigInt(accessKey.nonce) + 1n } }
     }
 
     const nonce = await TransactionBuilder.nonceManager.getNextNonce(
@@ -1207,13 +1224,36 @@ export class TransactionBuilder {
       },
     )
     const nonces = result?.nonces
-    if (!Array.isArray(nonces) || nonceIndex >= nonces.length) {
+    if (
+      !Array.isArray(nonces) ||
+      !Number.isInteger(nonceIndex) ||
+      nonceIndex < 0 ||
+      nonceIndex >= nonces.length
+    ) {
       throw new NearError(
         `Gas key ${publicKey} on ${this.signerId} has no nonce slot ${nonceIndex}`,
         "INVALID_TRANSACTION",
       )
     }
-    return BigInt(nonces[nonceIndex] as number | string)
+    const raw = nonces[nonceIndex]
+    // The RPC returns nonces as JSON numbers; guard against precision loss
+    // before widening to bigint, and accept a string form defensively.
+    if (typeof raw === "number") {
+      if (!Number.isSafeInteger(raw)) {
+        throw new NearError(
+          `Gas key nonce slot ${nonceIndex} is not a safe integer: ${raw}`,
+          "INVALID_TRANSACTION",
+        )
+      }
+      return BigInt(raw)
+    }
+    if (typeof raw === "string") {
+      return BigInt(raw)
+    }
+    throw new NearError(
+      `Gas key nonce slot ${nonceIndex} has an unexpected type: ${typeof raw}`,
+      "INVALID_TRANSACTION",
+    )
   }
 
   /**
@@ -1381,11 +1421,24 @@ export class TransactionBuilder {
           // Use akNonce from the error to update cache directly
           // This avoids refetching and thundering herd on retry
           if (this.cachedSignedTx) {
-            TransactionBuilder.nonceManager.updateAndGetNext(
-              this.signerId,
-              this.cachedSignedTx.signedTx.transaction.publicKey.toString(),
-              BigInt(error.akNonce),
-            )
+            const pk =
+              this.cachedSignedTx.signedTx.transaction.publicKey.toString()
+            // Gas-key transactions reserve nonces under a per-slot key
+            // (`pk#index`), so the retry must update that same key — not the
+            // bare `pk` — or it would keep signing with the stale slot nonce.
+            // Strict-nonce transactions bypass the cache entirely (they refetch
+            // ak_nonce + 1 each attempt), so no cache update is needed there.
+            if (!this.strictNonce) {
+              const cacheKey =
+                this.gasKeyNonceIndex !== undefined
+                  ? `${pk}#${this.gasKeyNonceIndex}`
+                  : pk
+              TransactionBuilder.nonceManager.updateAndGetNext(
+                this.signerId,
+                cacheKey,
+                BigInt(error.akNonce),
+              )
+            }
           }
 
           // If we have retries left, continue the loop to rebuild with fresh nonce

--- a/packages/near-kit/tests/integration/gas-key-signing.test.ts
+++ b/packages/near-kit/tests/integration/gas-key-signing.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Integration test for the gas-key signing path (TransactionV1, NEAR 2.13).
+ *
+ * End-to-end: create an account, add a gas full-access key with several nonce
+ * slots, fund it, then SIGN A TRANSFER WITH THE GAS KEY and have a real 2.13
+ * node accept and execute it. This is the definitive proof of the V1 wire
+ * format (the `[0x01]`-tagged transaction carrying a `GasKeyNonce`) plus the
+ * gas-key signing path.
+ *
+ * Both the setup (add + fund) and the gas-key-signed transfer use the default
+ * status-bearing send and assert real execution success; the gas-key action /
+ * permission RPC views (in #196) parse the echoed responses.
+ *
+ * Sandbox version overridable via NEAR_SANDBOX_VERSION; defaults to a 2.13 RC.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+import { Near } from "../../src/core/near.js"
+import { Sandbox } from "../../src/sandbox/sandbox.js"
+import { generateKey } from "../../src/utils/key.js"
+
+const SANDBOX_VERSION = process.env.NEAR_SANDBOX_VERSION ?? "2.13.0-rc.2"
+
+describe("Gas Key Signing - Integration Test (NEAR 2.13)", () => {
+  let sandbox: Sandbox
+  let near: Near
+
+  beforeAll(async () => {
+    sandbox = await Sandbox.start({ version: SANDBOX_VERSION })
+    near = new Near({
+      network: sandbox,
+      keyStore: {
+        [sandbox.rootAccount.id]: sandbox.rootAccount.secretKey,
+      },
+    })
+    console.log(
+      `✓ Sandbox ${SANDBOX_VERSION} started: ${sandbox.rootAccount.id}`,
+    )
+  }, 180000)
+
+  afterAll(async () => {
+    if (sandbox) {
+      await sandbox.stop()
+    }
+  })
+
+  test("signs a transfer with a funded gas key (V1 GasKeyNonce)", async () => {
+    const accountId = `gks-${Date.now()}.${sandbox.rootAccount.id}`
+    const accountKey = generateKey()
+    const gasKey = generateKey()
+    const beneficiary = `gks-recv-${Date.now()}.${sandbox.rootAccount.id}`
+
+    // Create the gas-key owner and a transfer recipient.
+    await near
+      .transaction(sandbox.rootAccount.id)
+      .createAccount(accountId)
+      .transfer(accountId, "20 NEAR")
+      .addKey(accountKey.publicKey.toString(), { type: "fullAccess" })
+      .send()
+    await near
+      .transaction(sandbox.rootAccount.id)
+      .createAccount(beneficiary)
+      .transfer(beneficiary, "1 NEAR")
+      .send()
+
+    const ownerNear = new Near({
+      network: sandbox,
+      keyStore: { [accountId]: accountKey.secretKey },
+    })
+
+    // Add a gas full-access key (4 nonce slots) and fund it, atomically. Default
+    // (status-bearing) send asserts the setup executed; the gas-key action and
+    // permission views (added in #196) parse the echoed response.
+    const setup = await ownerNear
+      .transaction(accountId)
+      .addKey(gasKey.publicKey.toString(), {
+        type: "gasKeyFullAccess",
+        numNonces: 4,
+      })
+      .transferToGasKey(gasKey.publicKey.toString(), "5 NEAR")
+      .send()
+    expect("SuccessValue" in (setup.status as object)).toBe(true)
+
+    // Read back the gas key's nonce slots to confirm it is queryable before we
+    // sign with it.
+    const nonces = (
+      await near.rpc.call<{ nonces?: number[] }>(
+        "EXPERIMENTAL_view_gas_key_nonces",
+        {
+          finality: "optimistic",
+          account_id: accountId,
+          public_key: gasKey.publicKey.toString(),
+        },
+      )
+    ).nonces
+    expect(nonces).toHaveLength(4)
+    console.log(`✓ Gas key funded with ${nonces?.length} nonce slots`)
+
+    // Sign a transfer WITH the gas key, using nonce slot 0. This builds and
+    // signs a V1 transaction whose nonce is a GasKeyNonce { nonce, index }.
+    const result = await ownerNear
+      .transaction(accountId)
+      .signWith(gasKey.secretKey)
+      .useGasKey(0)
+      .transfer(beneficiary, "1 NEAR")
+      .send()
+
+    // Status-bearing response: assert the node executed it successfully.
+    expect(result.status).toBeDefined()
+    expect("Failure" in (result.status as object)).toBe(false)
+    expect("SuccessValue" in (result.status as object)).toBe(true)
+    console.log(
+      `✓ Gas-key-signed transfer executed: ${result.transaction?.hash}`,
+    )
+  }, 120000)
+})

--- a/packages/near-kit/tests/integration/gas-key-signing.test.ts
+++ b/packages/near-kit/tests/integration/gas-key-signing.test.ts
@@ -113,4 +113,39 @@ describe("Gas Key Signing - Integration Test (NEAR 2.13)", () => {
       `✓ Gas-key-signed transfer executed: ${result.transaction?.hash}`,
     )
   }, 120000)
+
+  test("strict nonce mode sends a transfer accepted by the node", async () => {
+    // Strict mode requires nonce === ak_nonce + 1; the builder bypasses the
+    // monotonic nonce cache and fetches the chain nonce directly. This proves
+    // the resulting V1 (strict) transaction is accepted on-chain.
+    const accountId = `strict-${Date.now()}.${sandbox.rootAccount.id}`
+    const accountKey = generateKey()
+    const recipientId = `strict-recv-${Date.now()}.${sandbox.rootAccount.id}`
+
+    await near
+      .transaction(sandbox.rootAccount.id)
+      .createAccount(accountId)
+      .transfer(accountId, "10 NEAR")
+      .addKey(accountKey.publicKey.toString(), { type: "fullAccess" })
+      .send()
+    await near
+      .transaction(sandbox.rootAccount.id)
+      .createAccount(recipientId)
+      .transfer(recipientId, "1 NEAR")
+      .send()
+
+    const accountNear = new Near({
+      network: sandbox,
+      keyStore: { [accountId]: accountKey.secretKey },
+    })
+
+    const result = await accountNear
+      .transaction(accountId)
+      .strictNonceMode()
+      .transfer(recipientId, "1 NEAR")
+      .send()
+
+    expect("SuccessValue" in (result.status as object)).toBe(true)
+    console.log(`✓ Strict-nonce transfer executed: ${result.transaction?.hash}`)
+  }, 120000)
 })

--- a/packages/near-kit/tests/unit/transaction-builder.test.ts
+++ b/packages/near-kit/tests/unit/transaction-builder.test.ts
@@ -600,6 +600,39 @@ describe("TransactionBuilder - Gas Keys (NEAR 2.13)", () => {
   })
 })
 
+describe("TransactionBuilder - V1 nonce options (NEAR 2.13)", () => {
+  test("useGasKey records the nonce index and marks the tx V1", () => {
+    const builder = createBuilder().useGasKey(2)
+
+    // @ts-expect-error - accessing private field for testing
+    expect(builder.gasKeyNonceIndex).toBe(2)
+    // @ts-expect-error - accessing private method for testing
+    expect(builder.requiresV1()).toBe(true)
+  })
+
+  test("strictNonceMode marks the tx V1", () => {
+    const builder = createBuilder().strictNonceMode()
+
+    // @ts-expect-error - accessing private field for testing
+    expect(builder.strictNonce).toBe(true)
+    // @ts-expect-error - accessing private method for testing
+    expect(builder.requiresV1()).toBe(true)
+  })
+
+  test("an ordinary transaction stays V0", () => {
+    const builder = createBuilder().transfer("bob.near", Amount.NEAR(1))
+
+    // @ts-expect-error - accessing private method for testing
+    expect(builder.requiresV1()).toBe(false)
+  })
+
+  test("rejects an out-of-range gas key nonce index", () => {
+    expect(() => createBuilder().useGasKey(-1)).toThrow(/0\.\.=65535/)
+    expect(() => createBuilder().useGasKey(70000)).toThrow(/0\.\.=65535/)
+    expect(() => createBuilder().useGasKey(1.5)).toThrow(/0\.\.=65535/)
+  })
+})
+
 describe("TransactionBuilder - NEP-616 StateInit", () => {
   test("should chain stateInit action with account ID reference", () => {
     const builder = createBuilder().stateInit({

--- a/packages/near-kit/tests/unit/transaction-v1.test.ts
+++ b/packages/near-kit/tests/unit/transaction-v1.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the versioned (V1) transaction encoding (gas keys / strict nonce, NEAR 2.13).
+ *
+ * Wire-format facts (from nearcore core/primitives/src/transaction.rs):
+ * - A V0 transaction is serialized TAG-LESS (legacy struct); a V1 transaction is
+ *   `[0x01] ++ borsh(TransactionV1)`.
+ * - Deserialization reads 2 bytes: 2nd byte 0 => V0; 1st byte 1 & 2nd != 0 => V1.
+ * - TransactionNonce: 0 = Nonce { nonce: u64 }, 1 = GasKeyNonce { nonce: u64, nonce_index: u16 }.
+ * - NonceMode: 0 = Monotonic, 1 = Strict.
+ * - TransactionV1 field order: signer_id, public_key, nonce, receiver_id,
+ *   block_hash, actions, nonce_mode.
+ */
+
+import { describe, expect, test } from "vitest"
+import { transfer } from "../../src/core/actions.js"
+import {
+  NonceModeSchema,
+  serializeSignedTransactionV1,
+  serializeTransaction,
+  serializeTransactionV1,
+  TransactionNonceSchema,
+  type TransactionV1,
+  TransactionV1Schema,
+} from "../../src/core/schema.js"
+import {
+  type Ed25519PublicKey,
+  type Ed25519Signature,
+  KeyType,
+} from "../../src/core/types.js"
+
+const pk: Ed25519PublicKey = {
+  keyType: KeyType.ED25519,
+  data: new Uint8Array(32).fill(7),
+  toString: () => "ed25519:test",
+}
+
+const sig: Ed25519Signature = {
+  keyType: KeyType.ED25519,
+  data: new Uint8Array(64).fill(9),
+}
+
+const baseV1 = (): TransactionV1 => ({
+  signerId: "alice.near",
+  publicKey: pk,
+  nonce: { gasKeyNonce: { nonce: 42n, nonceIndex: 3 } },
+  receiverId: "bob.near",
+  blockHash: new Uint8Array(32).fill(5),
+  actions: [transfer(1000n)],
+  nonceMode: { monotonic: {} },
+})
+
+describe("TransactionNonce schema", () => {
+  test("Nonce variant is discriminant 0", () => {
+    const bytes = TransactionNonceSchema.serialize({ nonce: { nonce: 1n } })
+    expect(bytes[0]).toBe(0)
+    // disc(1) + u64(8)
+    expect(bytes.length).toBe(1 + 8)
+  })
+
+  test("GasKeyNonce variant is discriminant 1 with nonce + index", () => {
+    const bytes = TransactionNonceSchema.serialize({
+      gasKeyNonce: { nonce: 1n, nonceIndex: 2 },
+    })
+    expect(bytes[0]).toBe(1)
+    // disc(1) + u64(8) + u16(2)
+    expect(bytes.length).toBe(1 + 8 + 2)
+  })
+
+  test("round-trips both variants", () => {
+    for (const value of [
+      { nonce: { nonce: 123n } },
+      { gasKeyNonce: { nonce: 456n, nonceIndex: 7 } },
+    ]) {
+      const bytes = TransactionNonceSchema.serialize(value)
+      expect(TransactionNonceSchema.deserialize(bytes)).toEqual(value)
+    }
+  })
+})
+
+describe("NonceMode schema", () => {
+  test("Monotonic is discriminant 0, Strict is discriminant 1", () => {
+    expect(NonceModeSchema.serialize({ monotonic: {} })[0]).toBe(0)
+    expect(NonceModeSchema.serialize({ strict: {} })[0]).toBe(1)
+  })
+})
+
+describe("V1 transaction serialization", () => {
+  test("prepends the 0x01 version tag", () => {
+    const bytes = serializeTransactionV1(baseV1())
+    expect(bytes[0]).toBe(1)
+  })
+
+  test("V1 wire bytes are V1 per nearcore's 2-byte discriminator", () => {
+    // 1st byte == 1 (version tag); 2nd byte is the low byte of the signer_id
+    // length prefix (10 for "alice.near"), which is nonzero => V1.
+    const bytes = serializeTransactionV1(baseV1())
+    expect(bytes[0]).toBe(1)
+    expect(bytes[1]).not.toBe(0)
+  })
+
+  test("V0 stays tag-less and reads as V0 (2nd byte 0)", () => {
+    // The default (V0) encoding must remain backward compatible: its 2nd byte is
+    // the high byte of the signer_id u32 length, which is 0 for any real id.
+    const v0 = serializeTransaction({
+      signerId: "alice.near",
+      publicKey: pk,
+      nonce: 42n,
+      receiverId: "bob.near",
+      blockHash: new Uint8Array(32).fill(5),
+      actions: [transfer(1000n)],
+    })
+    expect(v0[1]).toBe(0)
+  })
+
+  test("round-trips the inner struct after stripping the tag", () => {
+    const v1 = baseV1()
+    const bytes = serializeTransactionV1(v1)
+    // Deserialize the struct (skip the 1-byte version tag).
+    const decoded = TransactionV1Schema.deserialize(bytes.slice(1))
+
+    expect(decoded.signerId).toBe("alice.near")
+    expect(decoded.receiverId).toBe("bob.near")
+    expect(decoded.nonce).toEqual({
+      gasKeyNonce: { nonce: 42n, nonceIndex: 3 },
+    })
+    expect(decoded.nonceMode).toEqual({ monotonic: {} })
+    expect(decoded.publicKey).toEqual({
+      ed25519Key: { data: Array(32).fill(7) },
+    })
+  })
+
+  test("signed V1 = tagged tx bytes followed by the signature", () => {
+    const v1 = baseV1()
+    const txBytes = serializeTransactionV1(v1)
+    const signed = serializeSignedTransactionV1(v1, sig)
+
+    expect(signed.length).toBe(txBytes.length + 1 + 64)
+    // First bytes equal the tagged transaction.
+    expect(Array.from(signed.slice(0, txBytes.length))).toEqual(
+      Array.from(txBytes),
+    )
+    // Signature: ed25519 discriminant 0 then 64 bytes of 9.
+    expect(signed[txBytes.length]).toBe(0)
+    expect(signed[txBytes.length + 1]).toBe(9)
+  })
+
+  test("strict nonce mode flips the trailing mode byte", () => {
+    const monotonic = serializeTransactionV1(baseV1())
+    const strict = serializeTransactionV1({
+      ...baseV1(),
+      nonceMode: { strict: {} },
+    })
+    // Same length; differ only in the trailing nonce_mode discriminant byte.
+    expect(strict.length).toBe(monotonic.length)
+    expect(strict[strict.length - 1]).toBe(1)
+    expect(monotonic[monotonic.length - 1]).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Stacked on #196 (gas-key actions/permissions) — based against `main`, so this diff currently also contains #196's commits; they drop out once #196 merges and this is rebased.

Adds the versioned (V1) transaction encoding so a gas key can sign, plus strict nonce mode.

- `core/schema.ts`: `TransactionNonce` (`Nonce`=0 / `GasKeyNonce`=1), `NonceMode` (`Monotonic`=0 / `Strict`=1), `TransactionV1`, and serializers applying the custom `[0x01]` version tag. V0 stays tag-less and unchanged, preserving the V0/V1 byte discriminator nearcore relies on.
- `core/transaction.ts`: `.useGasKey(nonceIndex)` signs with a gas key (carries a `GasKeyNonce`; per-slot nonce fetched via `EXPERIMENTAL_view_gas_key_nonces`, tracked independently per slot) and `.strictNonceMode()` opts into strict validation. Both switch to the V1 signing path; the V1 wire bytes are cached and used by `serialize()`/`send()`.

V1 is strictly additive — ordinary transactions stay V0.

## Test plan

- [x] Unit: V1 tag byte; `TransactionNonce`/`NonceMode` discriminants; struct round-trip; signed-V1 layout; V0 backward-compat discriminator; builder state + index validation.
- [x] Integration: a `2.13.0-rc.2` sandbox accepts and **executes** a transfer signed with a gas key (V1 `GasKeyNonce`).
- [x] build + typecheck + lint + `test:unit` pass.

Read-path note: the gas-key add/fund setup uses `waitUntil:"NONE"` and confirms execution out-of-band; a `// TODO(TS-A view schemas)` marks where to tighten once the keys+rpc track adds the gas-key action/permission RPC views.