### PR TITLE
feat(actions): DelegateV2 meta-transactions (NEAR 2.13)

### DIFF
--- a/.changeset/delegate-v2.md
+++ b/.changeset/delegate-v2.md
@@ -1,0 +1,10 @@
+---
+"near-kit": minor
+---
+
+Add DelegateV2 meta-transactions (NEAR 2.13 / protocol v85)
+
+- `Action::DelegateV2` (borsh discriminant 14) with `VersionedDelegateActionPayload` / `DelegateActionV2`, whose nonce is a `TransactionNonce` so it can target a gas key's nonce slot.
+- Signed under a DISTINCT NEP-461 domain tag (NEP-611, `2^30 + 611`), so a V1 delegate signature is never valid for a V2 action.
+- Builder `.delegateV2({ nonceIndex? })` to sign a V2 delegate action and `.signedDelegateActionV2()` for relayers, plus `encodeSignedDelegateActionV2` / `decodeSignedDelegateActionV2` for transport.
+- RPC view schema for the `DelegateV2` action, so a relay transaction's default `.send()` path parses the echoed response.

--- a/packages/near-kit/src/core/actions.ts
+++ b/packages/near-kit/src/core/actions.ts
@@ -13,6 +13,7 @@ import type {
   AddKeyAction,
   ClassicAction,
   CreateAccountAction,
+  DelegateV2Action,
   DeleteAccountAction,
   DeleteKeyAction,
   DeployContractAction,
@@ -21,8 +22,10 @@ import type {
   FunctionCallAction,
   FunctionCallPermissionBorsh,
   GasKeyInfoBorsh,
+  NonDelegateActionBorsh,
   SignedDelegateAction,
   StakeAction,
+  TransactionNonceBorsh,
   TransferAction,
   TransferToGasKeyAction,
   UseGlobalContractAction,
@@ -66,6 +69,56 @@ export class DelegateAction {
     this.nonce = nonce
     this.maxBlockHeight = maxBlockHeight
     this.publicKey = publicKey
+  }
+}
+
+/**
+ * Delegate action V2 for gas-key meta-transactions (NEP-611 / NEAR 2.13).
+ *
+ * Like {@link DelegateAction} but its `nonce` is a {@link TransactionNonceBorsh}
+ * (so it can target a gas key's nonce slot), and it is signed under a DISTINCT
+ * NEP-461 domain tag — a V1 delegate signature is never valid for a V2 action.
+ * The `actions` are full (non-delegate) actions and must already be in
+ * Borsh-ready form (as returned by the action factories).
+ */
+export class DelegateActionV2 {
+  senderId: string
+  receiverId: string
+  actions: NonDelegateActionBorsh[]
+  nonce: TransactionNonceBorsh
+  maxBlockHeight: bigint
+  publicKey: PublicKey
+
+  constructor(
+    senderId: string,
+    receiverId: string,
+    actions: NonDelegateActionBorsh[],
+    nonce: TransactionNonceBorsh,
+    maxBlockHeight: bigint,
+    publicKey: PublicKey,
+  ) {
+    this.senderId = senderId
+    this.receiverId = receiverId
+    this.actions = actions
+    this.nonce = nonce
+    this.maxBlockHeight = maxBlockHeight
+    this.publicKey = publicKey
+  }
+
+  /**
+   * Convert to the Borsh-ready shape consumed by
+   * {@link serializeDelegateActionV2} and {@link signedDelegateV2}.
+   * @internal
+   */
+  toBorsh() {
+    return {
+      senderId: this.senderId,
+      receiverId: this.receiverId,
+      actions: this.actions,
+      nonce: this.nonce,
+      maxBlockHeight: this.maxBlockHeight,
+      publicKey: publicKeyToZorsh(this.publicKey),
+    }
   }
 }
 
@@ -438,6 +491,25 @@ export function signedDelegate(
         maxBlockHeight: delegateAction.maxBlockHeight,
         publicKey: publicKeyToZorsh(delegateAction.publicKey),
       },
+      signature: signatureToZorsh(signature),
+    },
+  }
+}
+
+/**
+ * Create a V2 signed delegate action (gas-key meta-transactions, NEAR 2.13).
+ *
+ * Wraps the signed V2 payload in `Action::DelegateV2` (discriminant 14). The
+ * signature must have been produced over {@link serializeDelegateActionV2} of
+ * the same delegate action.
+ */
+export function signedDelegateV2(
+  delegateAction: DelegateActionV2,
+  signature: Signature,
+): DelegateV2Action {
+  return {
+    delegateV2: {
+      delegateAction: { v2: delegateAction.toBorsh() },
       signature: signatureToZorsh(signature),
     },
   }

--- a/packages/near-kit/src/core/rpc/rpc-schemas.ts
+++ b/packages/near-kit/src/core/rpc/rpc-schemas.ts
@@ -511,6 +511,32 @@ export const ActionSchema = z.union([
       amount: z.string(), // yoctoNEAR as string
     }),
   }),
+  // DelegateV2 (NEAR 2.13). The node echoes the versioned payload externally
+  // tagged as { V2: {...} }; the nonce is a TransactionNonce view
+  // ({ Nonce: { nonce } } | { GasKeyNonce: { nonce, nonce_index } }).
+  z.object({
+    DelegateV2: z.object({
+      delegate_action: z.object({
+        V2: z.object({
+          sender_id: z.string(),
+          receiver_id: z.string(),
+          actions: z.array(z.any()),
+          nonce: z.union([
+            z.object({ Nonce: z.object({ nonce: z.number() }) }),
+            z.object({
+              GasKeyNonce: z.object({
+                nonce: z.number(),
+                nonce_index: z.number(),
+              }),
+            }),
+          ]),
+          max_block_height: z.number(),
+          public_key: z.string(),
+        }),
+      }),
+      signature: z.string(),
+    }),
+  }),
 ])
 
 /**

--- a/packages/near-kit/src/core/schema.ts
+++ b/packages/near-kit/src/core/schema.ts
@@ -37,6 +37,16 @@ import { KeyType } from "./types.js"
  */
 export const DELEGATE_ACTION_PREFIX = 1073742190
 
+/**
+ * Prefix for V2 delegate actions (gas-key meta transactions, NEP-611).
+ * Value: 2^30 + 611 = 1073742435
+ *
+ * This is the NEP-461 domain tag for `DelegateActionV2`. It is DISTINCT from
+ * {@link DELEGATE_ACTION_PREFIX}, so a V1 delegate signature is never valid for
+ * a V2 delegate action and vice versa.
+ */
+export const DELEGATE_ACTION_V2_PREFIX = 1073742435
+
 // ==================== Public Key ====================
 
 /**
@@ -326,6 +336,35 @@ const DeterministicStateInitSchema = b.struct({
   deposit: b.u128(),
 })
 
+// ==================== Transaction Nonce / Mode (NEAR 2.13) ====================
+//
+// Defined here (ahead of the action/delegate schemas) because DelegateActionV2
+// uses TransactionNonce, and they are leaf enums with no forward dependencies.
+
+/**
+ * TransactionNonce enum (NEAR 2.13).
+ *
+ * Variant order is the Borsh discriminant and MUST match nearcore:
+ * 0 = `Nonce { nonce: u64 }` (ordinary access keys),
+ * 1 = `GasKeyNonce { nonce: u64, nonce_index: u16 }` (gas keys).
+ */
+export const TransactionNonceSchema = b.enum({
+  nonce: b.struct({ nonce: b.u64() }),
+  gasKeyNonce: b.struct({ nonce: b.u64(), nonceIndex: b.u16() }),
+})
+
+/**
+ * NonceMode enum (NEAR 2.13).
+ *
+ * Variant order is the Borsh discriminant and MUST match nearcore:
+ * 0 = `Monotonic` (default; any nonce strictly greater than the access key
+ * nonce), 1 = `Strict` (nonce must be exactly `ak_nonce + 1`).
+ */
+export const NonceModeSchema = b.enum({
+  monotonic: b.struct({}),
+  strict: b.struct({}),
+})
+
 // ==================== Delegate Actions ====================
 
 /**
@@ -391,6 +430,85 @@ const SignedDelegateSchema = b.struct({
   signature: SignatureSchema,
 })
 
+// ==================== DelegateV2 (gas-key meta-transactions, NEAR 2.13) ====================
+//
+// `DelegateActionV2` is like the NEP-366 `DelegateAction` but its `nonce` is a
+// `TransactionNonce` (gas-key capable). It is carried by `Action::DelegateV2`
+// (discriminant 14) inside a versioned payload, and is signed under a DISTINCT
+// NEP-461 domain tag (NEP-611), so V1 delegate signatures are NOT valid for V2.
+
+/**
+ * Actions allowed inside a DelegateActionV2, mirroring nearcore's
+ * `NonDelegateAction` (which wraps the full `Action` enum and rejects nested
+ * delegates at runtime).
+ *
+ * The Borsh discriminants MUST match `Action` exactly (0..=13). A zorsh enum
+ * assigns discriminants positionally, so slot 8 (`Action::Delegate`) is kept as
+ * a placeholder to keep slots 9..=13 aligned with the protocol; it is never
+ * emitted because delegate actions cannot be nested. This deliberately differs
+ * from the V1 `ClassicActionsSchema`, whose discriminants drift past index 8.
+ */
+const NonDelegateActionSchema = b.enum({
+  createAccount: CreateAccountSchema,
+  deployContract: DeployContractSchema,
+  functionCall: FunctionCallSchema,
+  transfer: TransferSchema,
+  stake: StakeSchema,
+  addKey: AddKeySchema,
+  deleteKey: DeleteKeySchema,
+  deleteAccount: DeleteAccountSchema,
+  // Slot 8 = Action::Delegate. Placeholder for discriminant alignment only;
+  // nested delegate actions are forbidden, so this is never serialized.
+  signedDelegate: SignedDelegateSchema,
+  deployGlobalContract: DeployGlobalContractSchema,
+  useGlobalContract: UseGlobalContractSchema,
+  deterministicStateInit: DeterministicStateInitSchema,
+  transferToGasKey: TransferToGasKeySchema,
+  withdrawFromGasKey: WithdrawFromGasKeySchema,
+})
+
+/**
+ * DelegateActionV2 struct (NEAR 2.13).
+ *
+ * Field order matches nearcore `DelegateActionV2`: sender_id, receiver_id,
+ * actions, nonce (a {@link TransactionNonceSchema}), max_block_height, public_key.
+ */
+const DelegateActionV2Schema = b.struct({
+  senderId: b.string(),
+  receiverId: b.string(),
+  actions: b.vec(NonDelegateActionSchema),
+  nonce: TransactionNonceSchema,
+  maxBlockHeight: b.u64(),
+  publicKey: PublicKeySchema,
+})
+
+/**
+ * VersionedDelegateActionPayload enum (NEAR 2.13).
+ *
+ * Borsh discriminant 0 = `V2(DelegateActionV2)`. The variant is part of the
+ * signed payload, so a signature can't be ambiguous across versions.
+ */
+const VersionedDelegateActionPayloadSchema = b.enum({
+  v2: DelegateActionV2Schema,
+})
+
+/**
+ * VersionedSignedDelegateAction struct (NEAR 2.13).
+ *
+ * The payload carried by `Action::DelegateV2`: a versioned delegate-action
+ * payload plus its signature.
+ */
+const VersionedSignedDelegateActionSchema = b.struct({
+  delegateAction: VersionedDelegateActionPayloadSchema,
+  signature: SignatureSchema,
+})
+
+export type NonDelegateActionBorsh = b.infer<typeof NonDelegateActionSchema>
+export type DelegateActionV2Borsh = b.infer<typeof DelegateActionV2Schema>
+export type VersionedSignedDelegateActionBorsh = b.infer<
+  typeof VersionedSignedDelegateActionSchema
+>
+
 /**
  * Action enum matching NEAR protocol action discriminants
  * Order matters! Each position corresponds to the action type index:
@@ -408,6 +526,7 @@ const SignedDelegateSchema = b.struct({
  * 11 = DeterministicStateInit (NEP-616)
  * 12 = TransferToGasKey (protocol v85 / NEAR 2.13)
  * 13 = WithdrawFromGasKey (protocol v85 / NEAR 2.13)
+ * 14 = DelegateV2 (protocol v85 / NEAR 2.13)
  */
 export const ActionSchema = b.enum({
   createAccount: CreateAccountSchema,
@@ -424,6 +543,7 @@ export const ActionSchema = b.enum({
   deterministicStateInit: DeterministicStateInitSchema,
   transferToGasKey: TransferToGasKeySchema,
   withdrawFromGasKey: WithdrawFromGasKeySchema,
+  delegateV2: VersionedSignedDelegateActionSchema,
 })
 
 /**
@@ -466,6 +586,9 @@ export type TransferToGasKeyAction = {
 }
 export type WithdrawFromGasKeyAction = {
   withdrawFromGasKey: b.infer<typeof WithdrawFromGasKeySchema>
+}
+export type DelegateV2Action = {
+  delegateV2: b.infer<typeof VersionedSignedDelegateActionSchema>
 }
 
 // Export StateInit types for NEP-616
@@ -512,30 +635,6 @@ export const SignedTransactionSchema = b.struct({
  * @internal
  */
 const TRANSACTION_V1_TAG = 1
-
-/**
- * TransactionNonce enum (NEAR 2.13).
- *
- * Variant order is the Borsh discriminant and MUST match nearcore:
- * 0 = `Nonce { nonce: u64 }` (ordinary access keys),
- * 1 = `GasKeyNonce { nonce: u64, nonce_index: u16 }` (gas keys).
- */
-export const TransactionNonceSchema = b.enum({
-  nonce: b.struct({ nonce: b.u64() }),
-  gasKeyNonce: b.struct({ nonce: b.u64(), nonceIndex: b.u16() }),
-})
-
-/**
- * NonceMode enum (NEAR 2.13).
- *
- * Variant order is the Borsh discriminant and MUST match nearcore:
- * 0 = `Monotonic` (default; any nonce strictly greater than the access key
- * nonce), 1 = `Strict` (nonce must be exactly `ak_nonce + 1`).
- */
-export const NonceModeSchema = b.enum({
-  monotonic: b.struct({}),
-  strict: b.struct({}),
-})
 
 /**
  * TransactionV1 schema (NEAR 2.13).
@@ -801,6 +900,34 @@ export function serializeDelegateAction(
   return result
 }
 
+/**
+ * Serialize a V2 delegate action for signing (NEP-611 / NEAR 2.13).
+ *
+ * Prepends the DISTINCT V2 domain tag ({@link DELEGATE_ACTION_V2_PREFIX}) and
+ * wraps the action in the versioned payload enum (`V2` => `[0x00]`), exactly as
+ * nearcore's `VersionedDelegateActionPayload::get_nep461_hash` does. The result
+ * is hashed (SHA-256) and signed.
+ *
+ * @param delegateAction - The V2 delegate action in Borsh-ready form (its
+ *   `publicKey` already converted via {@link publicKeyToZorsh}).
+ */
+export function serializeDelegateActionV2(
+  delegateAction: DelegateActionV2Borsh,
+): Uint8Array {
+  const prefixBytes = b.u32().serialize(DELEGATE_ACTION_V2_PREFIX)
+  // The signed payload is the *versioned payload enum*, so the V2 variant tag
+  // (0x00) is part of the bytes.
+  const payloadBytes = VersionedDelegateActionPayloadSchema.serialize({
+    v2: delegateAction,
+  })
+
+  const result = new Uint8Array(prefixBytes.length + payloadBytes.length)
+  result.set(prefixBytes, 0)
+  result.set(payloadBytes, prefixBytes.length)
+
+  return result
+}
+
 export type DelegateActionPayloadFormat = "base64" | "bytes"
 
 type DelegatePayloadReturn<F extends DelegateActionPayloadFormat> =
@@ -842,5 +969,40 @@ export function decodeSignedDelegateAction(
   const bytes = typeof payload === "string" ? base64.decode(payload) : payload
   return {
     signedDelegate: SignedDelegateSchema.deserialize(bytes),
+  }
+}
+
+/**
+ * Encode a V2 signed delegate action ({@link DelegateV2Action}) for transport.
+ *
+ * - Default output is a base64 string that can be sent via JSON/HTTP.
+ * - Pass `"bytes"` to receive a raw Uint8Array.
+ */
+export function encodeSignedDelegateActionV2(
+  signedDelegate: DelegateV2Action,
+): string
+export function encodeSignedDelegateActionV2<
+  F extends DelegateActionPayloadFormat,
+>(signedDelegate: DelegateV2Action, format: F): DelegatePayloadReturn<F>
+export function encodeSignedDelegateActionV2(
+  signedDelegate: DelegateV2Action,
+  format: DelegateActionPayloadFormat = "base64",
+): string | Uint8Array {
+  const serialized = VersionedSignedDelegateActionSchema.serialize(
+    signedDelegate.delegateV2,
+  )
+  return format === "base64" ? base64.encode(serialized) : serialized
+}
+
+/**
+ * Decode an encoded V2 payload (base64 string or bytes) back into a
+ * {@link DelegateV2Action}.
+ */
+export function decodeSignedDelegateActionV2(
+  payload: string | Uint8Array,
+): DelegateV2Action {
+  const bytes = typeof payload === "string" ? base64.decode(payload) : payload
+  return {
+    delegateV2: VersionedSignedDelegateActionSchema.deserialize(bytes),
   }
 }

--- a/packages/near-kit/src/core/schema.ts
+++ b/packages/near-kit/src/core/schema.ts
@@ -459,9 +459,11 @@ const NonDelegateActionSchema = b.enum({
   addKey: AddKeySchema,
   deleteKey: DeleteKeySchema,
   deleteAccount: DeleteAccountSchema,
-  // Slot 8 = Action::Delegate. Placeholder for discriminant alignment only;
-  // nested delegate actions are forbidden, so this is never serialized.
-  signedDelegate: SignedDelegateSchema,
+  // Slot 8 = Action::Delegate. Placeholder for discriminant alignment only.
+  // An empty-struct schema is used (not SignedDelegateSchema) so a caller can't
+  // construct a nested V1 delegate inside a DelegateV2 payload; nested delegate
+  // actions are forbidden by the protocol and this is never serialized.
+  delegatePlaceholder: CreateAccountSchema,
   deployGlobalContract: DeployGlobalContractSchema,
   useGlobalContract: UseGlobalContractSchema,
   deterministicStateInit: DeterministicStateInitSchema,
@@ -505,7 +507,15 @@ const VersionedSignedDelegateActionSchema = b.struct({
   signature: SignatureSchema,
 })
 
-export type NonDelegateActionBorsh = b.infer<typeof NonDelegateActionSchema>
+/**
+ * Actions allowed inside a DelegateActionV2. Excludes the
+ * `delegatePlaceholder` (discriminant-alignment-only) variant so callers cannot
+ * construct a nested delegate action.
+ */
+export type NonDelegateActionBorsh = Exclude<
+  b.infer<typeof NonDelegateActionSchema>,
+  { delegatePlaceholder: unknown }
+>
 export type DelegateActionV2Borsh = b.infer<typeof DelegateActionV2Schema>
 export type VersionedSignedDelegateActionBorsh = b.infer<
   typeof VersionedSignedDelegateActionSchema

--- a/packages/near-kit/src/core/schema.ts
+++ b/packages/near-kit/src/core/schema.ts
@@ -442,11 +442,13 @@ const SignedDelegateSchema = b.struct({
  * `NonDelegateAction` (which wraps the full `Action` enum and rejects nested
  * delegates at runtime).
  *
- * The Borsh discriminants MUST match `Action` exactly (0..=13). A zorsh enum
- * assigns discriminants positionally, so slot 8 (`Action::Delegate`) is kept as
- * a placeholder to keep slots 9..=13 aligned with the protocol; it is never
- * emitted because delegate actions cannot be nested. This deliberately differs
- * from the V1 `ClassicActionsSchema`, whose discriminants drift past index 8.
+ * The Borsh discriminants MUST match the corresponding `Action` variants. A
+ * zorsh enum assigns discriminants positionally, so slot 8 (`Action::Delegate`)
+ * is kept as a placeholder to keep slots 9..=13 aligned with the protocol; it is
+ * never emitted because delegate actions cannot be nested. Both delegate
+ * variants are intentionally absent: slot 8 (`Delegate`) is a placeholder and
+ * slot 14 (`DelegateV2`) is simply not listed, since a delegate action cannot
+ * contain another delegate action.
  */
 const NonDelegateActionSchema = b.enum({
   createAccount: CreateAccountSchema,

--- a/packages/near-kit/src/core/transaction.ts
+++ b/packages/near-kit/src/core/transaction.ts
@@ -914,22 +914,28 @@ export class TransactionBuilder {
       )
     }
 
+    if (opts.nonceIndex !== undefined) {
+      TransactionBuilder.validateNonceIndex(opts.nonceIndex)
+    }
+
     // Resolve the underlying u64 nonce, then wrap it as a TransactionNonce
     // (GasKeyNonce when a slot index is given, plain Nonce otherwise).
+    const pkString = delegatePublicKey.toString()
     let nonceValue: bigint
     if (opts.nonce !== undefined) {
       nonceValue = opts.nonce
     } else if (opts.nonceIndex !== undefined) {
-      nonceValue =
-        (await this.fetchGasKeyNonce(
-          delegatePublicKey.toString(),
-          opts.nonceIndex,
-        )) + 1n
-    } else {
-      const accessKey = await this.rpc.getAccessKey(
+      // Reserve the per-slot nonce through the shared NonceManager (keyed by
+      // `pk#index`), so concurrent gas-key delegate signings on the same slot
+      // get distinct nonces instead of all fetching the same chain value.
+      const index = opts.nonceIndex
+      nonceValue = await TransactionBuilder.nonceManager.getNextNonce(
         this.signerId,
-        delegatePublicKey.toString(),
+        `${pkString}#${index}`,
+        async () => this.fetchGasKeyNonce(pkString, index),
       )
+    } else {
+      const accessKey = await this.rpc.getAccessKey(this.signerId, pkString)
       nonceValue = BigInt(accessKey.nonce) + 1n
     }
     const txNonce: TransactionNonceBorsh =
@@ -1074,14 +1080,24 @@ export class TransactionBuilder {
    * @remarks Combine with {@link signWith} to use the gas key's private key.
    */
   useGasKey(nonceIndex: number): this {
+    TransactionBuilder.validateNonceIndex(nonceIndex)
+    this.gasKeyNonceIndex = nonceIndex
+    return this.invalidateCache()
+  }
+
+  /**
+   * Validate a gas-key nonce index: an integer in the u16 range (`0..=65535`).
+   * The slot must also be within the key's allocated slots, which is checked
+   * when the nonce is fetched.
+   * @internal
+   */
+  private static validateNonceIndex(nonceIndex: number): void {
     if (!Number.isInteger(nonceIndex) || nonceIndex < 0 || nonceIndex > 65535) {
       throw new NearError(
         `Gas key nonceIndex must be an integer in 0..=65535, got ${nonceIndex}`,
         "INVALID_TRANSACTION",
       )
     }
-    this.gasKeyNonceIndex = nonceIndex
-    return this.invalidateCache()
   }
 
   /**

--- a/packages/near-kit/src/core/transaction.ts
+++ b/packages/near-kit/src/core/transaction.ts
@@ -54,9 +54,13 @@ import {
   type AccessKeyPermissionBorsh,
   type ClassicAction,
   type DelegateActionPayloadFormat,
+  type DelegateV2Action,
   encodeSignedDelegateAction,
+  encodeSignedDelegateActionV2,
+  type NonDelegateActionBorsh,
   type SignedDelegateAction,
   serializeDelegateAction,
+  serializeDelegateActionV2,
   serializeSignedTransaction,
   serializeSignedTransactionV1,
   serializeTransaction,
@@ -134,6 +138,25 @@ export type DelegateActionResult<
   F extends DelegateActionPayloadFormat = "base64",
 > = {
   signedDelegateAction: SignedDelegateAction
+  payload: F extends "bytes" ? Uint8Array : string
+  format: F
+}
+
+type DelegateV2Options<F extends DelegateActionPayloadFormat = "base64"> =
+  DelegateSigningOptions & {
+    payloadFormat?: F
+    /**
+     * Gas-key nonce slot to sign against. When set, the delegate action's nonce
+     * is a `GasKeyNonce { nonce, nonceIndex }` and the per-slot nonce is fetched
+     * via `EXPERIMENTAL_view_gas_key_nonces` (unless `nonce` is also given).
+     */
+    nonceIndex?: number
+  }
+
+export type DelegateV2ActionResult<
+  F extends DelegateActionPayloadFormat = "base64",
+> = {
+  signedDelegateAction: DelegateV2Action
   payload: F extends "bytes" ? Uint8Array : string
   format: F
 }
@@ -694,6 +717,19 @@ export class TransactionBuilder {
   }
 
   /**
+   * Add a V2 signed delegate action to this transaction, for relayers
+   * (gas-key meta-transactions, NEAR 2.13).
+   *
+   * The receiver is set to the V2 delegate action's sender (the account whose
+   * actions are being relayed).
+   */
+  signedDelegateActionV2(signedDelegate: DelegateV2Action): this {
+    this.actions.push(signedDelegate)
+    this.receiverId = signedDelegate.delegateV2.delegateAction.v2.senderId
+    return this.invalidateCache()
+  }
+
+  /**
    * Build and sign a delegate action from the queued actions.
    *
    * @returns Structured delegate action plus an encoded payload (`base64` by default)
@@ -812,6 +848,121 @@ export class TransactionBuilder {
     )
     const format = (opts.payloadFormat ?? "base64") as F
     const payload = encodeSignedDelegateAction(signedDelegateAction, format)
+
+    return {
+      signedDelegateAction,
+      payload,
+      format,
+    }
+  }
+
+  /**
+   * Build and sign a V2 delegate action (gas-key meta-transactions, NEAR 2.13).
+   *
+   * Like {@link delegate} but produces a `DelegateActionV2`, signed under the
+   * DISTINCT V2 NEP-461 domain tag. Pass `nonceIndex` to sign against a gas
+   * key's nonce slot (the nonce then carries that index); otherwise an ordinary
+   * key nonce is used. A relayer wraps the returned payload in a transaction via
+   * {@link signedDelegateActionV2}.
+   *
+   * @returns The structured V2 signed delegate action plus an encoded payload
+   *   (`base64` by default).
+   */
+  async delegateV2<F extends DelegateActionPayloadFormat = "base64">(
+    options?: DelegateV2Options<F>,
+  ): Promise<DelegateV2ActionResult<F>> {
+    const opts = options ?? ({} as DelegateV2Options<F>)
+    if (this.actions.length === 0) {
+      throw new NearError(
+        "Delegate action requires at least one action to perform",
+        "INVALID_TRANSACTION",
+      )
+    }
+
+    if (
+      this.actions.some(
+        (action) => "signedDelegate" in action || "delegateV2" in action,
+      )
+    ) {
+      throw new NearError(
+        "Delegate actions cannot contain nested delegate actions",
+        "INVALID_TRANSACTION",
+      )
+    }
+
+    const receiverId = opts.receiverId ?? this.receiverId
+    if (!receiverId) {
+      throw new NearError(
+        "Delegate action requires a receiver. Set receiverId via the first action or provide it explicitly.",
+        "INVALID_TRANSACTION",
+      )
+    }
+
+    const keyPair = await this.resolveKeyPair()
+    let delegatePublicKey: PublicKey
+    if (opts.publicKey === undefined) {
+      delegatePublicKey = keyPair.publicKey
+    } else if (typeof opts.publicKey === "string") {
+      delegatePublicKey = parsePublicKey(opts.publicKey)
+    } else {
+      delegatePublicKey = opts.publicKey
+    }
+
+    if (!publicKeysEqual(delegatePublicKey, keyPair.publicKey)) {
+      throw new InvalidKeyError(
+        "Delegate action public key must match the signer key. Use signWith() when you need a different key.",
+      )
+    }
+
+    // Resolve the underlying u64 nonce, then wrap it as a TransactionNonce
+    // (GasKeyNonce when a slot index is given, plain Nonce otherwise).
+    let nonceValue: bigint
+    if (opts.nonce !== undefined) {
+      nonceValue = opts.nonce
+    } else if (opts.nonceIndex !== undefined) {
+      nonceValue =
+        (await this.fetchGasKeyNonce(
+          delegatePublicKey.toString(),
+          opts.nonceIndex,
+        )) + 1n
+    } else {
+      const accessKey = await this.rpc.getAccessKey(
+        this.signerId,
+        delegatePublicKey.toString(),
+      )
+      nonceValue = BigInt(accessKey.nonce) + 1n
+    }
+    const txNonce: TransactionNonceBorsh =
+      opts.nonceIndex !== undefined
+        ? { gasKeyNonce: { nonce: nonceValue, nonceIndex: opts.nonceIndex } }
+        : { nonce: { nonce: nonceValue } }
+
+    let maxBlockHeight: bigint
+    if (opts.maxBlockHeight !== undefined) {
+      maxBlockHeight = opts.maxBlockHeight
+    } else {
+      const status = await this.rpc.getStatus()
+      const offset = BigInt(opts.blockHeightOffset ?? 200)
+      maxBlockHeight = BigInt(status.sync_info.latest_block_height) + offset
+    }
+
+    const delegateAction = new actions.DelegateActionV2(
+      this.signerId,
+      receiverId,
+      this.actions as NonDelegateActionBorsh[],
+      txNonce,
+      maxBlockHeight,
+      delegatePublicKey,
+    )
+
+    const hash = sha256(serializeDelegateActionV2(delegateAction.toBorsh()))
+    const signature = keyPair.sign(hash)
+    const signedDelegateAction = actions.signedDelegateV2(
+      delegateAction,
+      signature,
+    )
+    const format = (opts.payloadFormat ?? "base64") as F
+    const payload = encodeSignedDelegateActionV2(signedDelegateAction, format)
 
     return {
       signedDelegateAction,

--- a/packages/near-kit/src/index.ts
+++ b/packages/near-kit/src/index.ts
@@ -5,20 +5,28 @@
 // Contract types
 export type { Contract, ContractMethods } from "./contracts/contract.js"
 // Delegate actions
-export { DelegateAction } from "./core/actions.js"
+export { DelegateAction, DelegateActionV2 } from "./core/actions.js"
 // Constants
 export { STORAGE_AMOUNT_PER_BYTE } from "./core/constants.js"
 // Main class
 export { Near } from "./core/near.js"
 export {
   DELEGATE_ACTION_PREFIX,
+  DELEGATE_ACTION_V2_PREFIX,
   type DelegateActionPayloadFormat,
+  type DelegateV2Action,
   decodeSignedDelegateAction,
+  decodeSignedDelegateActionV2,
   encodeSignedDelegateAction,
+  encodeSignedDelegateActionV2,
   type SignedDelegateAction,
   serializeDelegateAction,
+  serializeDelegateActionV2,
 } from "./core/schema.js"
-export type { DelegateActionResult } from "./core/transaction.js"
+export type {
+  DelegateActionResult,
+  DelegateV2ActionResult,
+} from "./core/transaction.js"
 export { TransactionBuilder } from "./core/transaction.js"
 // Types
 export type {

--- a/packages/near-kit/tests/integration/delegate-v2.test.ts
+++ b/packages/near-kit/tests/integration/delegate-v2.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Integration test for DelegateV2 meta-transactions (NEAR 2.13).
+ *
+ * End-to-end relay: a sender signs a `DelegateActionV2` (under the V2 NEP-461
+ * domain tag); a separate relayer wraps it in `Action::DelegateV2` and submits
+ * it, and a real 2.13 node accepts and EXECUTES the inner transfer. This proves
+ * the V2 wire format and the V2 signing domain tag on-chain.
+ *
+ * The default (status-bearing) send asserts execution success and exercises the
+ * DelegateV2 RPC action view; the recipient balance delta confirms the inner
+ * transfer moved funds.
+ *
+ * Sandbox version overridable via NEAR_SANDBOX_VERSION; defaults to a 2.13 RC.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+import { Near } from "../../src/core/near.js"
+import { Sandbox } from "../../src/sandbox/sandbox.js"
+import { generateKey } from "../../src/utils/key.js"
+
+const SANDBOX_VERSION = process.env.NEAR_SANDBOX_VERSION ?? "2.13.0-rc.2"
+
+describe("DelegateV2 - Integration Test (NEAR 2.13)", () => {
+  let sandbox: Sandbox
+  let near: Near
+
+  beforeAll(async () => {
+    sandbox = await Sandbox.start({ version: SANDBOX_VERSION })
+    near = new Near({
+      network: sandbox,
+      keyStore: {
+        [sandbox.rootAccount.id]: sandbox.rootAccount.secretKey,
+      },
+    })
+    console.log(
+      `✓ Sandbox ${SANDBOX_VERSION} started: ${sandbox.rootAccount.id}`,
+    )
+  }, 180000)
+
+  afterAll(async () => {
+    if (sandbox) {
+      await sandbox.stop()
+    }
+  })
+
+  test("relays a V2 signed delegate action on-chain", async () => {
+    const senderId = `dv2-sender-${Date.now()}.${sandbox.rootAccount.id}`
+    const senderKey = generateKey()
+    const recipientId = `dv2-recv-${Date.now()}.${sandbox.rootAccount.id}`
+
+    // Create the sender (with its own full-access key) and the recipient.
+    await near
+      .transaction(sandbox.rootAccount.id)
+      .createAccount(senderId)
+      .transfer(senderId, "10 NEAR")
+      .addKey(senderKey.publicKey.toString(), { type: "fullAccess" })
+      .send()
+    await near
+      .transaction(sandbox.rootAccount.id)
+      .createAccount(recipientId)
+      .transfer(recipientId, "1 NEAR")
+      .send()
+
+    const senderNear = new Near({
+      network: sandbox,
+      keyStore: { [senderId]: senderKey.secretKey },
+    })
+
+    // The sender signs a V2 delegate action (ordinary nonce, not a gas key):
+    // "transfer 1 NEAR from me to the recipient".
+    const { signedDelegateAction } = await senderNear
+      .transaction(senderId)
+      .transfer(recipientId, "1 NEAR")
+      .delegateV2({ payloadFormat: "bytes" })
+
+    const balanceBefore = Number.parseFloat(await near.getBalance(recipientId))
+
+    // The relayer (root) wraps the V2 signed delegate and submits it. Default
+    // (status-bearing) send: the response echoes the DelegateV2 action, so this
+    // also exercises the DelegateV2 RPC action view.
+    const result = await near
+      .transaction(sandbox.rootAccount.id)
+      .signedDelegateActionV2(signedDelegateAction)
+      .send()
+    expect("Failure" in (result.status as object)).toBe(false)
+    expect("SuccessValue" in (result.status as object)).toBe(true)
+
+    // And the inner transfer actually moved funds.
+    const balanceAfter = Number.parseFloat(await near.getBalance(recipientId))
+    expect(balanceAfter).toBeGreaterThan(balanceBefore + 0.5)
+    console.log(`✓ DelegateV2 relayed and executed: ${recipientId} funded`)
+  }, 120000)
+})

--- a/packages/near-kit/tests/unit/delegate-v2.test.ts
+++ b/packages/near-kit/tests/unit/delegate-v2.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for DelegateV2 meta-transactions (gas keys, NEAR 2.13).
+ *
+ * Wire-format facts (from nearcore core/primitives/src/action/delegate.rs and
+ * signable_message.rs):
+ * - Action::DelegateV2 = discriminant 14.
+ * - The signed payload is the *versioned payload enum*
+ *   `VersionedDelegateActionPayload::V2(DelegateActionV2)` (variant tag 0x00),
+ *   prefixed with the NEP-461 domain tag for NEP-611 = 2^30 + 611 = 1073742435.
+ *   This DIFFERS from the V1 delegate tag (2^30 + 366 = 1073742190), so a V1
+ *   signature is never valid for a V2 action.
+ * - DelegateActionV2 nonce is a TransactionNonce (gas-key capable).
+ */
+
+import { describe, expect, test } from "vitest"
+import {
+  DelegateActionV2,
+  signedDelegateV2,
+  transfer,
+} from "../../src/core/actions.js"
+import {
+  ActionSchema,
+  DELEGATE_ACTION_PREFIX,
+  DELEGATE_ACTION_V2_PREFIX,
+  decodeSignedDelegateActionV2,
+  encodeSignedDelegateActionV2,
+  serializeDelegateActionV2,
+} from "../../src/core/schema.js"
+import {
+  type Ed25519PublicKey,
+  type Ed25519Signature,
+  KeyType,
+} from "../../src/core/types.js"
+
+const pk: Ed25519PublicKey = {
+  keyType: KeyType.ED25519,
+  data: new Uint8Array(32).fill(8),
+  toString: () => "ed25519:test",
+}
+
+const sig: Ed25519Signature = {
+  keyType: KeyType.ED25519,
+  data: new Uint8Array(64).fill(12),
+}
+
+const baseAction = () =>
+  new DelegateActionV2(
+    "alice.near",
+    "bob.near",
+    [transfer(1000n)],
+    { gasKeyNonce: { nonce: 5n, nonceIndex: 2 } },
+    1000n,
+    pk,
+  )
+
+describe("DelegateV2 domain tag", () => {
+  test("V2 prefix is 2^30 + 611 and distinct from V1", () => {
+    expect(DELEGATE_ACTION_V2_PREFIX).toBe(1073742435)
+    expect(DELEGATE_ACTION_V2_PREFIX).not.toBe(DELEGATE_ACTION_PREFIX)
+  })
+
+  test("serializeDelegateActionV2 starts with the V2 prefix (LE u32)", () => {
+    const bytes = serializeDelegateActionV2(baseAction().toBorsh())
+    // 1073742435 = 0x40000263, little-endian: 63 02 00 40
+    expect(bytes[0]).toBe(0x63)
+    expect(bytes[1]).toBe(0x02)
+    expect(bytes[2]).toBe(0x00)
+    expect(bytes[3]).toBe(0x40)
+  })
+
+  test("the versioned payload variant tag (0x00) follows the prefix", () => {
+    const bytes = serializeDelegateActionV2(baseAction().toBorsh())
+    // After the 4-byte prefix comes the VersionedDelegateActionPayload enum tag.
+    expect(bytes[4]).toBe(0)
+  })
+
+  test("V2 signing bytes differ from a hypothetical V1 prefix", () => {
+    // A V1 delegate signature is not valid for V2: the signed bytes start with a
+    // different domain tag, so the hashes (and thus signatures) cannot collide.
+    const v2 = serializeDelegateActionV2(baseAction().toBorsh())
+    const v1Prefix = new Uint8Array([0x6e, 0x01, 0x00, 0x40]) // 1073742190 LE
+    expect(Array.from(v2.slice(0, 4))).not.toEqual(Array.from(v1Prefix))
+  })
+})
+
+describe("DelegateV2 action", () => {
+  test("Action::DelegateV2 serializes with discriminant 14", () => {
+    const action = signedDelegateV2(baseAction(), sig)
+    expect("delegateV2" in action).toBe(true)
+
+    const bytes = ActionSchema.serialize(action)
+    expect(bytes[0]).toBe(14)
+  })
+
+  test("signedDelegateV2 carries the versioned payload and signature", () => {
+    const action = signedDelegateV2(baseAction(), sig)
+    expect(action.delegateV2.delegateAction.v2.senderId).toBe("alice.near")
+    expect(action.delegateV2.delegateAction.v2.nonce).toEqual({
+      gasKeyNonce: { nonce: 5n, nonceIndex: 2 },
+    })
+  })
+
+  test("Action::DelegateV2 round-trips through ActionSchema", () => {
+    const action = signedDelegateV2(baseAction(), sig)
+    const bytes = ActionSchema.serialize(action)
+    expect(ActionSchema.deserialize(bytes)).toEqual(action)
+  })
+
+  test("an ordinary-nonce V2 delegate uses the Nonce variant", () => {
+    const action = signedDelegateV2(
+      new DelegateActionV2(
+        "alice.near",
+        "bob.near",
+        [transfer(1n)],
+        { nonce: { nonce: 9n } },
+        500n,
+        pk,
+      ),
+      sig,
+    )
+    expect(action.delegateV2.delegateAction.v2.nonce).toEqual({
+      nonce: { nonce: 9n },
+    })
+  })
+})
+
+describe("DelegateV2 encode/decode", () => {
+  test("round-trips to bytes and base64", () => {
+    const action = signedDelegateV2(baseAction(), sig)
+
+    const bytes = encodeSignedDelegateActionV2(action, "bytes")
+    expect(decodeSignedDelegateActionV2(bytes)).toEqual(action)
+
+    const b64 = encodeSignedDelegateActionV2(action)
+    expect(typeof b64).toBe("string")
+    expect(decodeSignedDelegateActionV2(b64)).toEqual(action)
+  })
+})

--- a/packages/near-kit/tests/unit/rpc-schemas.test.ts
+++ b/packages/near-kit/tests/unit/rpc-schemas.test.ts
@@ -152,4 +152,46 @@ describe("Gas key RPC views (NEAR 2.13)", () => {
     })
     expect(parsed.actions).toHaveLength(2)
   })
+
+  describe("response ActionSchema — DelegateV2 (NEAR 2.13)", () => {
+    test("parses a DelegateV2 action view with a GasKeyNonce", () => {
+      const view = {
+        DelegateV2: {
+          delegate_action: {
+            V2: {
+              sender_id: "alice.near",
+              receiver_id: "bob.near",
+              actions: [{ Transfer: { deposit: "1" } }],
+              nonce: { GasKeyNonce: { nonce: 5, nonce_index: 2 } },
+              max_block_height: 1000,
+              public_key:
+                "ed25519:8nFkHgRePSGD9UsK3Hx6nWKXGQ7Kd7k3k7k3k7k3k7k3",
+            },
+          },
+          signature: "ed25519:sig",
+        },
+      }
+      expect(ActionSchema.parse(view)).toEqual(view)
+    })
+
+    test("parses a DelegateV2 action view with a plain Nonce", () => {
+      const view = {
+        DelegateV2: {
+          delegate_action: {
+            V2: {
+              sender_id: "alice.near",
+              receiver_id: "bob.near",
+              actions: [],
+              nonce: { Nonce: { nonce: 9 } },
+              max_block_height: 500,
+              public_key:
+                "ed25519:8nFkHgRePSGD9UsK3Hx6nWKXGQ7Kd7k3k7k3k7k3k7k3",
+            },
+          },
+          signature: "ed25519:sig",
+        },
+      }
+      expect(ActionSchema.parse(view)).toEqual(view)
+    })
+  })
 })

--- a/packages/near-kit/tests/unit/transaction-builder.test.ts
+++ b/packages/near-kit/tests/unit/transaction-builder.test.ts
@@ -631,6 +631,20 @@ describe("TransactionBuilder - V1 nonce options (NEAR 2.13)", () => {
     expect(() => createBuilder().useGasKey(70000)).toThrow(/0\.\.=65535/)
     expect(() => createBuilder().useGasKey(1.5)).toThrow(/0\.\.=65535/)
   })
+
+  test("delegateV2 rejects an out-of-range gas key nonce index", async () => {
+    // The index is validated before any RPC call (after the local key is
+    // resolved via signWith), so this rejects without network access.
+    const builder = createBuilder()
+      .signWith(
+        "ed25519:3D4YudUahN1nawWogh8pAKSj92sUNMdbZGjn7kERKzYoTy8oryFtvLGoBnu1J6N4qVWY9jXwfLiNWnaTzKkHNfqG",
+      )
+      .transfer("bob.near", Amount.NEAR(1))
+
+    await expect(builder.delegateV2({ nonceIndex: -1 })).rejects.toThrow(
+      /0\.\.=65535/,
+    )
+  })
 })
 
 describe("TransactionBuilder - NEP-616 StateInit", () => {


### PR DESCRIPTION
## Summary

Stacked on #197 → #196 — based against `main`, so this diff currently also contains #196's and #197's commits; they drop out once those merge and this is rebased.

Adds `Action::DelegateV2` (discriminant 14), the gas-key-capable meta-transaction.

- `core/schema.ts`: `DelegateActionV2` / `VersionedDelegateActionPayload` (V2=0) / `VersionedSignedDelegateAction`; `Action::DelegateV2`=14; the DISTINCT V2 NEP-461 domain tag (`2^30 + 611` = 1073742435) and `serializeDelegateActionV2`; `encode`/`decode` for transport. Nested actions use the full `Action` discriminants (mirroring `NonDelegateAction`).
- `core/actions.ts`: `DelegateActionV2` class + `signedDelegateV2` helper.
- `core/transaction.ts`: `.delegateV2({ nonceIndex? })` to sign a V2 delegate (gas-key slot optional) and `.signedDelegateActionV2()` for relayers.

A V1 delegate signature is never valid for a V2 action (distinct domain tags). Additive — V1 delegate is unchanged.

## Test plan

- [x] Unit: V2 domain tag bytes (distinct from V1), versioned-payload variant tag, `Action::DelegateV2` discriminant 14 + round-trip, gas-key vs ordinary nonce, encode/decode round-trip.
- [x] Integration: a `2.13.0-rc.2` sandbox accepts a relayed `DelegateV2` and executes the inner transfer — full on-chain relay proof.
- [x] build + typecheck + lint + `test:unit` pass.

Read-path note: the relay send uses `waitUntil:"NONE"` and confirms execution via a balance delta; a `// TODO(TS-A view schemas)` marks where to tighten once the keys+rpc track adds the DelegateV2 action RPC view.