### PR TITLE
feat(rpc): add view_state pagination + stabilized 2.13 RPC wrappers

### DIFF
--- a/.changeset/view-state-rpc.md
+++ b/.changeset/view-state-rpc.md
@@ -4,5 +4,5 @@
 
 Add `view_state` with pagination and wrappers for RPC methods stabilized in nearcore 2.13
 
-- `near.viewState(accountId, { prefix, afterKey, limit, includeProof, ... })` reads a page of contract state; `near.viewStateAll(accountId, { prefix, limit })` is an async iterator that follows the `last_key` cursor across pages. Both are also on the low-level `near.rpc` client.
+- `near.viewState(accountId, { prefix, afterKey, limit, includeProof, ... })` reads a page of contract state; `near.viewStateAll(accountId, { prefix, limit })` is an async iterator that follows the `last_key` cursor across pages. Both are also on the low-level `near.rpc` client. `prefix` and `afterKey` are base64-encoded strings (sent as `prefix_base64`/`after_key_base64`); the returned `last_key` cursor is already base64, so pass it straight back as `afterKey`.
 - `near.rpc.blockEffects()`, `near.rpc.genesisConfig()`, and `near.rpc.maintenanceWindows(accountId)` wrap the stabilized methods, falling back to the `EXPERIMENTAL_*` aliases on pre-2.13 nodes.

--- a/.changeset/view-state-rpc.md
+++ b/.changeset/view-state-rpc.md
@@ -1,0 +1,8 @@
+---
+"near-kit": minor
+---
+
+Add `view_state` with pagination and wrappers for RPC methods stabilized in nearcore 2.13
+
+- `near.viewState(accountId, { prefix, afterKey, limit, includeProof, ... })` reads a page of contract state; `near.viewStateAll(accountId, { prefix, limit })` is an async iterator that follows the `last_key` cursor across pages. Both are also on the low-level `near.rpc` client.
+- `near.rpc.blockEffects()`, `near.rpc.genesisConfig()`, and `near.rpc.maintenanceWindows(accountId)` wrap the stabilized methods, falling back to the `EXPERIMENTAL_*` aliases on pre-2.13 nodes.

--- a/docs/in-depth/advanced-transactions.mdx
+++ b/docs/in-depth/advanced-transactions.mdx
@@ -198,14 +198,28 @@ It throws an `UnknownReceiptError` if the node doesn't know the receipt.
 
 `near.viewState()` reads a contract's raw key/value storage (base64-encoded). Pass a `prefix` to filter and `limit` to page; the response's `last_key` is the cursor for the next page (absent on the last page). Pagination requires **nearcore >= 2.13**.
 
+`prefix` and `afterKey` are **base64-encoded strings** — they're sent to the node as `prefix_base64` and `after_key_base64`. Likewise, the `last_key` cursor in the response is already base64, so pass it straight back as `afterKey` to fetch the next page. Returned `key`/`value` are also base64.
+
 ```typescript
-// One page
-const page = await near.viewState("contract.near", { limit: 100 })
+// One page (filter by a base64-encoded key prefix)
+const page = await near.viewState("contract.near", {
+  prefix: btoa("STATE"), // base64-encoded prefix
+  limit: 100,
+})
 for (const { key, value } of page.values) {
   // key/value are base64 strings
 }
 
-// Iterate everything, following the cursor across pages
+// Manually fetch the next page using the base64 cursor
+if (page.last_key) {
+  const next = await near.viewState("contract.near", {
+    prefix: btoa("STATE"),
+    afterKey: page.last_key, // base64 cursor from the previous page
+    limit: 100,
+  })
+}
+
+// Or iterate everything, following the cursor across pages automatically
 for await (const { key, value } of near.viewStateAll("contract.near", { limit: 100 })) {
   // ...
 }

--- a/docs/in-depth/advanced-transactions.mdx
+++ b/docs/in-depth/advanced-transactions.mdx
@@ -193,3 +193,35 @@ const { transaction_hash, sender_account_id } = await near.rpc.receiptToTx(
 ```
 
 It throws an `UnknownReceiptError` if the node doesn't know the receipt.
+
+## 8. Reading Raw Contract State
+
+`near.viewState()` reads a contract's raw key/value storage (base64-encoded). Pass a `prefix` to filter and `limit` to page; the response's `last_key` is the cursor for the next page (absent on the last page). Pagination requires **nearcore >= 2.13**.
+
+```typescript
+// One page
+const page = await near.viewState("contract.near", { limit: 100 })
+for (const { key, value } of page.values) {
+  // key/value are base64 strings
+}
+
+// Iterate everything, following the cursor across pages
+for await (const { key, value } of near.viewStateAll("contract.near", { limit: 100 })) {
+  // ...
+}
+```
+
+## 9. Stabilized RPC Methods (nearcore 2.13)
+
+Several `EXPERIMENTAL_` endpoints were stabilized in nearcore 2.13. `near.rpc` exposes the stable names and falls back to the `EXPERIMENTAL_` alias automatically on older nodes.
+
+```typescript
+// State-change kinds in a block (was EXPERIMENTAL_changes_in_block)
+const effects = await near.rpc.blockEffects({ finality: "final" })
+
+// Network genesis config (was EXPERIMENTAL_genesis_config)
+const genesis = await near.rpc.genesisConfig()
+
+// A validator's upcoming maintenance windows (block-height ranges)
+const windows = await near.rpc.maintenanceWindows("validator.near")
+```

--- a/packages/near-kit/src/core/near.ts
+++ b/packages/near-kit/src/core/near.ts
@@ -28,7 +28,9 @@ import type {
   AccessKeyView,
   FinalExecutionOutcome,
   FinalExecutionOutcomeWithReceiptsMap,
+  StateItem,
   StatusResponse,
+  ViewStateResult,
 } from "./rpc/rpc-schemas.js"
 import { TransactionBuilder } from "./transaction.js"
 import type {
@@ -809,6 +811,49 @@ export class Near {
    */
   async getStatus(): Promise<StatusResponse> {
     return this._rpc.getStatus()
+  }
+
+  /**
+   * Read a single page of a contract's state via `view_state`.
+   *
+   * Returns base64-encoded key/value entries. Use `options.afterKey` (the
+   * `last_key` from a previous page) to paginate, or {@link viewStateAll} to
+   * iterate everything.
+   *
+   * @param accountId - Account whose contract state to read.
+   * @param options - Optional `prefix`, `afterKey`, `limit`, `includeProof`, and block reference.
+   */
+  async viewState(
+    accountId: string,
+    options?: BlockReference & {
+      prefix?: string
+      afterKey?: string
+      limit?: number
+      includeProof?: boolean
+    },
+  ): Promise<ViewStateResult> {
+    return this._rpc.viewState(accountId, options)
+  }
+
+  /**
+   * Iterate every entry of a contract's state via `view_state`, following the
+   * pagination cursor across pages.
+   *
+   * @param accountId - Account whose contract state to read.
+   * @param options - Optional `prefix`, per-request `limit`, and block reference.
+   *
+   * @example
+   * ```typescript
+   * for await (const { key, value } of near.viewStateAll("contract.near")) {
+   *   // process each entry
+   * }
+   * ```
+   */
+  viewStateAll(
+    accountId: string,
+    options?: BlockReference & { prefix?: string; limit?: number },
+  ): AsyncGenerator<StateItem> {
+    return this._rpc.viewStateAll(accountId, options)
   }
 
   /**

--- a/packages/near-kit/src/core/rpc/rpc-schemas.ts
+++ b/packages/near-kit/src/core/rpc/rpc-schemas.ts
@@ -653,6 +653,95 @@ export const FinalExecutionOutcomeWithReceiptsSchema = z.intersection(
   }),
 )
 
+// ==================== view_state ====================
+
+/**
+ * A single key/value entry from a `view_state` query.
+ * `key` and `value` are base64-encoded byte strings.
+ */
+export const StateItemSchema = z.object({
+  key: z.string(),
+  value: z.string(),
+})
+
+/**
+ * Result of a `view_state` query.
+ *
+ * `last_key` is a base64 continuation cursor: pass it as `after_key_base64` on
+ * the next request to fetch the following page. It is absent on the last page.
+ * `proof` is present only when the query requested inclusion proofs.
+ */
+export const ViewStateResultSchema = z.object({
+  values: z.array(StateItemSchema),
+  proof: z.array(z.string()).optional(),
+  last_key: z.string().optional(),
+  block_height: z.number().optional(),
+  block_hash: z.string().optional(),
+})
+
+// ==================== block_effects / changes_in_block ====================
+
+/**
+ * A single state-change kind from `block_effects`
+ * (`EXPERIMENTAL_changes_in_block`), internally tagged by `type`.
+ */
+export const StateChangeKindSchema = z.object({
+  type: z.enum([
+    "account_touched",
+    "access_key_touched",
+    "data_touched",
+    "contract_code_touched",
+  ]),
+  account_id: z.string(),
+})
+
+/**
+ * Response of `block_effects` / `EXPERIMENTAL_changes_in_block`: the kinds of
+ * state changes that occurred in a block (without the changed values).
+ */
+export const BlockEffectsResponseSchema = z.object({
+  block_hash: z.string(),
+  changes: z.array(StateChangeKindSchema),
+})
+
+// ==================== maintenance_windows ====================
+
+/**
+ * A maintenance window as a half-open block-height range `[start, end)` during
+ * which the given validator is not expected to produce or validate.
+ */
+export const MaintenanceWindowSchema = z.object({
+  start: z.number(),
+  end: z.number(),
+})
+
+/**
+ * Response of `maintenance_windows`: the upcoming maintenance windows for a
+ * validator account, ordered by block height.
+ */
+export const MaintenanceWindowsResponseSchema = z.array(MaintenanceWindowSchema)
+
+// ==================== genesis_config ====================
+
+/**
+ * Response of `genesis_config` / `EXPERIMENTAL_genesis_config`.
+ *
+ * The genesis config is a large, version-dependent object; only the most
+ * commonly used fields are typed. Unknown fields are preserved via passthrough
+ * so callers can read everything the node returns.
+ */
+export const GenesisConfigResponseSchema = z
+  .object({
+    protocol_version: z.number(),
+    chain_id: z.string(),
+    genesis_height: z.number(),
+    genesis_time: z.string().optional(),
+    epoch_length: z.number().optional(),
+    num_block_producer_seats: z.number().optional(),
+    total_supply: z.string().optional(),
+  })
+  .catchall(z.any()) // Preserve all other genesis fields
+
 // ==================== Type Inference ====================
 
 /**
@@ -681,6 +770,15 @@ export type StatusResponse = z.infer<typeof StatusResponseSchema>
 export type GasPriceResponse = z.infer<typeof GasPriceResponseSchema>
 export type AccessKeyListResponse = z.infer<typeof AccessKeyListResponseSchema>
 export type ReceiptToTxResponse = z.infer<typeof ReceiptToTxResponseSchema>
+export type StateItem = z.infer<typeof StateItemSchema>
+export type ViewStateResult = z.infer<typeof ViewStateResultSchema>
+export type StateChangeKind = z.infer<typeof StateChangeKindSchema>
+export type BlockEffectsResponse = z.infer<typeof BlockEffectsResponseSchema>
+export type MaintenanceWindow = z.infer<typeof MaintenanceWindowSchema>
+export type MaintenanceWindowsResponse = z.infer<
+  typeof MaintenanceWindowsResponseSchema
+>
+export type GenesisConfigResponse = z.infer<typeof GenesisConfigResponseSchema>
 export type RpcErrorResponse = z.infer<typeof RpcErrorResponseSchema>
 
 /**

--- a/packages/near-kit/src/core/rpc/rpc.ts
+++ b/packages/near-kit/src/core/rpc/rpc.ts
@@ -722,7 +722,7 @@ export class RpcClient {
     const result = await this.callWithExperimentalFallback(
       "genesis_config",
       "EXPERIMENTAL_genesis_config",
-      null,
+      [],
     )
     return GenesisConfigResponseSchema.parse(result)
   }

--- a/packages/near-kit/src/core/rpc/rpc.ts
+++ b/packages/near-kit/src/core/rpc/rpc.ts
@@ -649,7 +649,9 @@ export class RpcClient {
         : { finality: options?.finality || "optimistic" }),
       account_id: accountId,
       prefix_base64: options?.prefix ?? "",
-      ...(options?.afterKey ? { after_key_base64: options.afterKey } : {}),
+      ...(options?.afterKey !== undefined
+        ? { after_key_base64: options.afterKey }
+        : {}),
       ...(options?.limit !== undefined ? { limit: options.limit } : {}),
       ...(options?.includeProof ? { include_proof: true } : {}),
     })
@@ -684,7 +686,7 @@ export class RpcClient {
     do {
       const page = await this.viewState(accountId, {
         ...options,
-        ...(afterKey ? { afterKey } : {}),
+        ...(afterKey !== undefined ? { afterKey } : {}),
       })
       yield* page.values
       afterKey = page.last_key

--- a/packages/near-kit/src/core/rpc/rpc.ts
+++ b/packages/near-kit/src/core/rpc/rpc.ts
@@ -9,6 +9,7 @@ import type {
   AccessKeyListResponse,
   AccessKeyView,
   AccountView,
+  BlockEffectsResponse,
   BlockView,
   ExecutionOutcomeWithId,
   FinalExecutionOutcome,
@@ -16,9 +17,13 @@ import type {
   FinalExecutionOutcomeWithReceipts,
   FinalExecutionOutcomeWithReceiptsMap,
   GasPriceResponse,
+  GenesisConfigResponse,
+  MaintenanceWindowsResponse,
   ReceiptToTxResponse,
+  StateItem,
   StatusResponse,
   ViewFunctionCallResult,
+  ViewStateResult,
 } from "../types.js"
 import {
   checkOutcomeForFunctionCallError,
@@ -31,13 +36,17 @@ import {
   AccessKeyListResponseSchema,
   AccessKeyViewSchema,
   AccountViewSchema,
+  BlockEffectsResponseSchema,
   BlockViewSchema,
   FinalExecutionOutcomeSchema,
   FinalExecutionOutcomeWithReceiptsSchema,
   GasPriceResponseSchema,
+  GenesisConfigResponseSchema,
+  MaintenanceWindowsResponseSchema,
   ReceiptToTxResponseSchema,
   StatusResponseSchema,
   ViewFunctionCallResultSchema,
+  ViewStateResultSchema,
 } from "./rpc-schemas.js"
 
 export interface RpcRequest {
@@ -599,4 +608,176 @@ export class RpcClient {
     const result = await this.call("gas_price", [blockId])
     return GasPriceResponseSchema.parse(result)
   }
+
+  /**
+   * Read a single page of contract state via `view_state`.
+   *
+   * Returns key/value entries (base64-encoded) whose keys start with `prefix`.
+   * When the result has a `last_key`, more entries remain: pass it as
+   * `options.afterKey` to fetch the next page, or use {@link viewStateAll} to
+   * iterate every page automatically.
+   *
+   * @param accountId - Account whose contract state to read.
+   * @param options - Optional pagination and block reference.
+   * @param options.prefix - Base64 key prefix to filter by (default: all keys).
+   * @param options.afterKey - Base64 continuation cursor from a prior `last_key`.
+   * @param options.limit - Maximum number of entries to return.
+   * @param options.includeProof - Request Merkle inclusion proofs.
+   *
+   * @example
+   * ```typescript
+   * const page = await rpc.viewState("contract.near", { limit: 100 })
+   * for (const { key, value } of page.values) { ... }
+   * if (page.last_key) {
+   *   const next = await rpc.viewState("contract.near", { afterKey: page.last_key })
+   * }
+   * ```
+   */
+  async viewState(
+    accountId: string,
+    options?: BlockReference & {
+      prefix?: string
+      afterKey?: string
+      limit?: number
+      includeProof?: boolean
+    },
+  ): Promise<ViewStateResult> {
+    const result = await this.call("query", {
+      request_type: "view_state",
+      ...(options?.blockId
+        ? { block_id: options.blockId }
+        : { finality: options?.finality || "optimistic" }),
+      account_id: accountId,
+      prefix_base64: options?.prefix ?? "",
+      ...(options?.afterKey ? { after_key_base64: options.afterKey } : {}),
+      ...(options?.limit !== undefined ? { limit: options.limit } : {}),
+      ...(options?.includeProof ? { include_proof: true } : {}),
+    })
+
+    parseQueryError(result, { accountId })
+
+    return ViewStateResultSchema.parse(result)
+  }
+
+  /**
+   * Iterate all contract state entries via `view_state`, following the
+   * `last_key` cursor across pages until exhausted.
+   *
+   * Yields one {@link StateItem} at a time so large state can be streamed
+   * without buffering it all in memory.
+   *
+   * @param accountId - Account whose contract state to read.
+   * @param options - Optional `prefix`, per-request `limit`, and block reference.
+   *
+   * @example
+   * ```typescript
+   * for await (const { key, value } of rpc.viewStateAll("contract.near", { limit: 100 })) {
+   *   // process each entry
+   * }
+   * ```
+   */
+  async *viewStateAll(
+    accountId: string,
+    options?: BlockReference & { prefix?: string; limit?: number },
+  ): AsyncGenerator<StateItem> {
+    let afterKey: string | undefined
+    do {
+      const page = await this.viewState(accountId, {
+        ...options,
+        ...(afterKey ? { afterKey } : {}),
+      })
+      yield* page.values
+      afterKey = page.last_key
+    } while (afterKey !== undefined)
+  }
+
+  /**
+   * Get the kinds of state changes in a block via `block_effects`
+   * (stabilized in nearcore 2.13; falls back to the `EXPERIMENTAL_changes_in_block`
+   * alias on older nodes).
+   *
+   * @param options - Block reference. Defaults to the latest final block.
+   */
+  async blockEffects(options?: BlockReference): Promise<BlockEffectsResponse> {
+    const params = options?.blockId
+      ? { block_id: options.blockId }
+      : { finality: options?.finality || "final" }
+
+    const result = await this.callWithExperimentalFallback(
+      "block_effects",
+      "EXPERIMENTAL_changes_in_block",
+      params,
+    )
+    return BlockEffectsResponseSchema.parse(result)
+  }
+
+  /**
+   * Get the network genesis configuration via `genesis_config` (stabilized in
+   * nearcore 2.13; falls back to the `EXPERIMENTAL_genesis_config` alias on
+   * older nodes).
+   */
+  async genesisConfig(): Promise<GenesisConfigResponse> {
+    const result = await this.callWithExperimentalFallback(
+      "genesis_config",
+      "EXPERIMENTAL_genesis_config",
+      null,
+    )
+    return GenesisConfigResponseSchema.parse(result)
+  }
+
+  /**
+   * Get the upcoming maintenance windows (half-open block-height ranges) for a
+   * validator account via `maintenance_windows` (stabilized in nearcore 2.13;
+   * falls back to the `EXPERIMENTAL_maintenance_windows` alias on older nodes).
+   *
+   * @param accountId - Validator account ID.
+   */
+  async maintenanceWindows(
+    accountId: string,
+  ): Promise<MaintenanceWindowsResponse> {
+    const result = await this.callWithExperimentalFallback(
+      "maintenance_windows",
+      "EXPERIMENTAL_maintenance_windows",
+      { account_id: accountId },
+    )
+    return MaintenanceWindowsResponseSchema.parse(result)
+  }
+
+  /**
+   * Call a method that was stabilized (renamed without the `EXPERIMENTAL_`
+   * prefix) in a recent protocol version, retrying with the legacy
+   * `EXPERIMENTAL_` alias if the node does not recognize the new name.
+   * @internal
+   */
+  private async callWithExperimentalFallback<T = unknown>(
+    method: string,
+    experimentalMethod: string,
+    params: unknown,
+  ): Promise<T> {
+    try {
+      return await this.call<T>(method, params)
+    } catch (error) {
+      if (isMethodNotFound(error)) {
+        return await this.call<T>(experimentalMethod, params)
+      }
+      throw error
+    }
+  }
+}
+
+/**
+ * Whether an error indicates the RPC method name is not recognized by the node
+ * (JSON-RPC -32601 "Method not found"), so a legacy alias should be tried.
+ *
+ * `parseRpcError` surfaces an unknown method as a `NetworkError` whose message
+ * carries the `METHOD_NOT_FOUND` cause and whose `statusCode` holds the
+ * JSON-RPC error code (-32601).
+ * @internal
+ */
+function isMethodNotFound(error: unknown): boolean {
+  if (error instanceof NetworkError && error.statusCode === -32601) {
+    return true
+  }
+  const message = error instanceof Error ? error.message : String(error)
+  return /method[\s_]not[\s_]found|-32601/i.test(message)
 }

--- a/packages/near-kit/src/core/rpc/rpc.ts
+++ b/packages/near-kit/src/core/rpc/rpc.ts
@@ -656,7 +656,11 @@ export class RpcClient {
       ...(options?.includeProof ? { include_proof: true } : {}),
     })
 
-    parseQueryError(result, { accountId })
+    // No access-key context: parseQueryError would otherwise misread a
+    // "does not exist" error (missing account/contract) as an
+    // AccessKeyDoesNotExistError. A view_state failure surfaces as a generic
+    // query error instead.
+    parseQueryError(result)
 
     return ViewStateResultSchema.parse(result)
   }

--- a/packages/near-kit/src/core/types.ts
+++ b/packages/near-kit/src/core/types.ts
@@ -254,14 +254,21 @@ export type {
   AccessKeyListResponse,
   AccessKeyView,
   AccountView,
+  BlockEffectsResponse,
   BlockHeaderView,
   BlockView,
   ChunkHeaderView,
   GasPriceResponse,
+  GenesisConfigResponse,
+  MaintenanceWindow,
+  MaintenanceWindowsResponse,
   ReceiptToTxResponse,
   RpcErrorResponse,
+  StateChangeKind,
+  StateItem,
   StatusResponse,
   ViewFunctionCallResult,
+  ViewStateResult,
 } from "./rpc/rpc-schemas.js"
 
 // ==================== Client Configuration ====================

--- a/packages/near-kit/tests/integration/view-state-rpc.test.ts
+++ b/packages/near-kit/tests/integration/view-state-rpc.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Integration tests for view_state pagination and the RPC methods stabilized in
+ * nearcore 2.13 (block_effects / genesis_config / maintenance_windows).
+ */
+
+import { base64 } from "@scure/base"
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+import { Near } from "../../src/core/near.js"
+import { EMPTY_CODE_HASH, Sandbox } from "../../src/sandbox/sandbox.js"
+
+// view_state `limit`/`after_key_base64` pagination was added in nearcore 2.13
+// (protocol v85). Older nodes ignore `limit` and return every entry, so the
+// pagination assertions only run against a 2.13.x sandbox.
+const VIEW_STATE_PAGINATION_PROTOCOL_VERSION = 85
+
+describe("view_state + stabilized RPC - Integration Tests", () => {
+  let sandbox: Sandbox
+  let near: Near
+  let stateAccount: string
+  let protocolVersion = 0
+
+  beforeAll(async () => {
+    sandbox = await Sandbox.start()
+    near = new Near({
+      network: sandbox,
+      keyStore: { [sandbox.rootAccount.id]: sandbox.rootAccount.secretKey },
+    })
+    protocolVersion = (await near.getStatus()).protocol_version
+
+    // Seed a contract account with deterministic state via patchState, so the
+    // pagination assertions don't depend on any contract's internal layout.
+    stateAccount = `state-${Date.now()}.${sandbox.rootAccount.id}`
+    const enc = new TextEncoder()
+    const data = Array.from({ length: 5 }, (_, i) => ({
+      Data: {
+        account_id: stateAccount,
+        data_key: base64.encode(enc.encode(`key-${i}`)),
+        value: base64.encode(enc.encode(`value-${i}`)),
+      },
+    }))
+    await sandbox.patchState([
+      {
+        Account: {
+          account_id: stateAccount,
+          account: {
+            amount: "100000000000000000000000000",
+            locked: "0",
+            code_hash: EMPTY_CODE_HASH,
+            storage_usage: 500,
+          },
+        },
+      },
+      ...data,
+    ])
+  }, 120000)
+
+  afterAll(async () => {
+    if (sandbox) await sandbox.stop()
+  })
+
+  test("view_state returns all seeded entries", async () => {
+    const result = await near.viewState(stateAccount)
+    expect(result.values.length).toBe(5)
+    const dec = new TextDecoder()
+    const keys = result.values
+      .map((v) => dec.decode(base64.decode(v.key)))
+      .sort()
+    expect(keys).toEqual(["key-0", "key-1", "key-2", "key-3", "key-4"])
+  })
+
+  test("view_state paginates via limit + last_key cursor", async (ctx) => {
+    if (protocolVersion < VIEW_STATE_PAGINATION_PROTOCOL_VERSION) {
+      console.warn(
+        `⚠ Skipping view_state pagination test: node is protocol ${protocolVersion}, ` +
+          `limit/after_key_base64 needs ${VIEW_STATE_PAGINATION_PROTOCOL_VERSION}+ (2.13.x sandbox)`,
+      )
+      ctx.skip()
+      return
+    }
+
+    const page1 = await near.viewState(stateAccount, { limit: 2 })
+    expect(page1.values.length).toBe(2)
+    expect(page1.last_key).toBeDefined()
+
+    const page2 = await near.viewState(stateAccount, {
+      limit: 2,
+      afterKey: page1.last_key,
+    })
+    expect(page2.values.length).toBeGreaterThan(0)
+    // Cursor advanced: page 2's first key differs from page 1's first key.
+    expect(page2.values[0]?.key).not.toBe(page1.values[0]?.key)
+  })
+
+  test("viewStateAll iterates every entry across pages", async () => {
+    const seen: string[] = []
+    for await (const item of near.viewStateAll(stateAccount, { limit: 2 })) {
+      seen.push(item.key)
+    }
+    expect(seen.length).toBe(5)
+    // No duplicates across page boundaries.
+    expect(new Set(seen).size).toBe(5)
+  })
+
+  test("genesis_config returns the chain config", async () => {
+    const cfg = await near.rpc.genesisConfig()
+    expect(cfg.chain_id).toBe("localnet")
+    expect(cfg.protocol_version).toBeGreaterThan(0)
+  })
+
+  test("block_effects returns state-change kinds for a block", async () => {
+    const effects = await near.rpc.blockEffects({ finality: "final" })
+    expect(typeof effects.block_hash).toBe("string")
+    expect(Array.isArray(effects.changes)).toBe(true)
+  })
+
+  test("maintenance_windows returns ranges for the validator", async () => {
+    const windows = await near.rpc.maintenanceWindows(sandbox.rootAccount.id)
+    expect(Array.isArray(windows)).toBe(true)
+    for (const w of windows) {
+      expect(w.end).toBeGreaterThanOrEqual(w.start)
+    }
+  })
+})

--- a/packages/near-kit/tests/integration/view-state-rpc.test.ts
+++ b/packages/near-kit/tests/integration/view-state-rpc.test.ts
@@ -9,8 +9,11 @@ import { Near } from "../../src/core/near.js"
 import { EMPTY_CODE_HASH, Sandbox } from "../../src/sandbox/sandbox.js"
 
 // view_state `limit`/`after_key_base64` pagination was added in nearcore 2.13
-// (protocol v85). Older nodes ignore `limit` and return every entry, so the
-// pagination assertions only run against a 2.13.x sandbox.
+// (protocol v85). Older nodes ignore `limit` and return every entry, so this
+// test pins a 2.13.x sandbox so the pagination assertions actually run rather
+// than relying on the (separately bumped) default version. The protocol guard
+// below stays as a safety net (e.g. an older NEAR_SANDBOX_BIN_PATH override).
+const VIEW_STATE_SANDBOX_VERSION = "2.13.0-rc.2"
 const VIEW_STATE_PAGINATION_PROTOCOL_VERSION = 85
 
 describe("view_state + stabilized RPC - Integration Tests", () => {
@@ -20,7 +23,7 @@ describe("view_state + stabilized RPC - Integration Tests", () => {
   let protocolVersion = 0
 
   beforeAll(async () => {
-    sandbox = await Sandbox.start()
+    sandbox = await Sandbox.start({ version: VIEW_STATE_SANDBOX_VERSION })
     near = new Near({
       network: sandbox,
       keyStore: { [sandbox.rootAccount.id]: sandbox.rootAccount.secretKey },

--- a/packages/near-kit/tests/integration/view-state-rpc.test.ts
+++ b/packages/near-kit/tests/integration/view-state-rpc.test.ts
@@ -7,6 +7,7 @@ import { base64 } from "@scure/base"
 import { afterAll, beforeAll, describe, expect, test } from "vitest"
 import { Near } from "../../src/core/near.js"
 import { EMPTY_CODE_HASH, Sandbox } from "../../src/sandbox/sandbox.js"
+import { generateKey } from "../../src/utils/key.js"
 
 // view_state `limit`/`after_key_base64` pagination was added in nearcore 2.13
 // (protocol v85). Older nodes ignore `limit` and return every entry, so this
@@ -111,9 +112,36 @@ describe("view_state + stabilized RPC - Integration Tests", () => {
   })
 
   test("block_effects returns state-change kinds for a block", async () => {
-    const effects = await near.rpc.blockEffects({ finality: "final" })
+    // Query a block that actually touched state (account creation) so the
+    // non-empty `changes` path is exercised — an idle block's `changes` is empty
+    // and would pass even against a wrong schema. block_effects returns a list
+    // of state-change KINDS ({ type, account_id }), not full changes-with-value.
+    const touched = `be-${Date.now()}.${sandbox.rootAccount.id}`
+    const key = generateKey()
+    const result = await near
+      .transaction(sandbox.rootAccount.id)
+      .createAccount(touched)
+      .transfer(touched, "1 NEAR")
+      .addKey(key.publicKey.toString(), { type: "fullAccess" })
+      .send({ waitUntil: "FINAL" })
+    // The new account's state change lands in the receipt's block, not the
+    // transaction's block, so query the receipt block.
+    const blockHash = result.receipts_outcome[0].block_hash
+
+    const effects = await near.rpc.blockEffects({ blockId: blockHash })
     expect(typeof effects.block_hash).toBe("string")
-    expect(Array.isArray(effects.changes)).toBe(true)
+    expect(effects.changes.length).toBeGreaterThan(0)
+    for (const change of effects.changes) {
+      expect([
+        "account_touched",
+        "access_key_touched",
+        "data_touched",
+        "contract_code_touched",
+      ]).toContain(change.type)
+      expect(typeof change.account_id).toBe("string")
+    }
+    // The created account must appear among the touched accounts.
+    expect(effects.changes.some((c) => c.account_id === touched)).toBe(true)
   })
 
   test("maintenance_windows returns ranges for the validator", async () => {

--- a/packages/near-kit/tests/unit/rpc-error-handler.test.ts
+++ b/packages/near-kit/tests/unit/rpc-error-handler.test.ts
@@ -157,6 +157,19 @@ describe("parseQueryError", () => {
     }
   })
 
+  test("should throw NetworkError (not AccessKeyDoesNotExistError) for 'does not exist' without access-key context", () => {
+    // This is the view_state case: a missing account/contract must surface as a
+    // generic query error, not be misclassified as an access-key error.
+    const result = {
+      error: "account some.near does not exist while viewing",
+    }
+
+    expect(() => parseQueryError(result)).toThrow(NetworkError)
+    expect(() => parseQueryError(result)).not.toThrow(
+      AccessKeyDoesNotExistError,
+    )
+  })
+
   test("should throw NetworkError when access key error lacks 'does not exist' substring", () => {
     const result = {
       error: "Permission denied for access key",

--- a/packages/near-kit/tests/unit/view-state-schemas.test.ts
+++ b/packages/near-kit/tests/unit/view-state-schemas.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for the view_state / stabilized-RPC response schemas.
+ */
+
+import { describe, expect, test } from "vitest"
+import {
+  BlockEffectsResponseSchema,
+  GenesisConfigResponseSchema,
+  MaintenanceWindowsResponseSchema,
+  ViewStateResultSchema,
+} from "../../src/core/rpc/rpc-schemas.js"
+
+describe("ViewStateResultSchema", () => {
+  test("parses a page with a continuation cursor", () => {
+    const parsed = ViewStateResultSchema.parse({
+      values: [
+        { key: "a2V5", value: "dmFsdWU=" },
+        { key: "azI=", value: "djI=" },
+      ],
+      last_key: "azI=",
+      block_height: 100,
+      block_hash: "abc",
+    })
+    expect(parsed.values).toHaveLength(2)
+    expect(parsed.last_key).toBe("azI=")
+  })
+
+  test("parses a final page (no last_key, no proof)", () => {
+    const parsed = ViewStateResultSchema.parse({ values: [] })
+    expect(parsed.values).toEqual([])
+    expect(parsed.last_key).toBeUndefined()
+    expect(parsed.proof).toBeUndefined()
+  })
+
+  test("accepts an inclusion proof when present", () => {
+    const parsed = ViewStateResultSchema.parse({
+      values: [{ key: "a2V5", value: "dg==" }],
+      proof: ["cHJvb2Yx", "cHJvb2Yy"],
+    })
+    expect(parsed.proof).toHaveLength(2)
+  })
+})
+
+describe("BlockEffectsResponseSchema", () => {
+  test("parses tagged state-change kinds", () => {
+    const parsed = BlockEffectsResponseSchema.parse({
+      block_hash: "Hhh",
+      changes: [
+        { type: "account_touched", account_id: "alice.near" },
+        { type: "data_touched", account_id: "contract.near" },
+      ],
+    })
+    expect(parsed.changes[0]?.type).toBe("account_touched")
+    expect(parsed.changes[1]?.account_id).toBe("contract.near")
+  })
+})
+
+describe("MaintenanceWindowsResponseSchema", () => {
+  test("parses an array of block-height ranges", () => {
+    const parsed = MaintenanceWindowsResponseSchema.parse([
+      { start: 100, end: 200 },
+      { start: 300, end: 400 },
+    ])
+    expect(parsed).toHaveLength(2)
+    expect(parsed[0]).toEqual({ start: 100, end: 200 })
+  })
+
+  test("parses an empty list", () => {
+    expect(MaintenanceWindowsResponseSchema.parse([])).toEqual([])
+  })
+})
+
+describe("GenesisConfigResponseSchema", () => {
+  test("parses known fields and preserves unknown ones", () => {
+    const parsed = GenesisConfigResponseSchema.parse({
+      protocol_version: 85,
+      chain_id: "localnet",
+      genesis_height: 0,
+      some_future_field: { nested: true },
+    })
+    expect(parsed.protocol_version).toBe(85)
+    expect(parsed.chain_id).toBe("localnet")
+    expect((parsed as Record<string, unknown>)["some_future_field"]).toEqual({
+      nested: true,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- `near.viewState(accountId, { prefix, afterKey, limit, includeProof, ... })` reads a page of contract state; `near.viewStateAll(...)` is an async iterator that follows the `last_key` cursor across pages. Both also on `near.rpc`.
- `near.rpc.blockEffects()` / `near.rpc.genesisConfig()` / `near.rpc.maintenanceWindows(accountId)` wrap the methods stabilized in nearcore 2.13, falling back to the `EXPERIMENTAL_*` aliases on older nodes.

## Test plan

- [x] `bun run build` + `bun run typecheck` + `bun run lint` clean
- [x] `bun run test:unit` (957 passing, incl. 7 new schema tests)
- [x] Integration tests against a 2.13.0-rc.2 sandbox: view_state full read + limit/cursor pagination + viewStateAll iteration + all three stabilized methods
- [x] Against a 2.12.0 sandbox the `EXPERIMENTAL_` fallback works; the pagination test (a v85 feature) skips