### PR TITLE
feat(rpc): type ExecutionMetadata V4 per-action contracts

### DIFF
--- a/.changeset/exec-metadata-v4.md
+++ b/.changeset/exec-metadata-v4.md
@@ -1,0 +1,7 @@
+---
+"near-kit": minor
+---
+
+Type ExecutionMetadata V4 per-action `contracts` (nearcore 2.13)
+
+`ExecutionMetadataSchema` is now a union discriminated on `version`. V4 metadata exposes a typed `contracts` array — one entry per action recording the contract attached to the receiver account before that action ran (`{ local } | { global_hash } | { global_account_id } | null`). V1-V3 parsing is unchanged, and unknown future versions still parse via a fallback.

--- a/packages/near-kit/src/core/rpc/rpc-schemas.ts
+++ b/packages/near-kit/src/core/rpc/rpc-schemas.ts
@@ -351,6 +351,8 @@ const ExecutionMetadataBaseSchema = z.object({
  * `null` when none). Unknown future versions fall back to the base shape so
  * parsing never throws on a newer node.
  */
+const KNOWN_METADATA_VERSIONS = new Set([1, 2, 3, 4])
+
 export const ExecutionMetadataSchema = z.union([
   // V4: typed per-action contracts.
   ExecutionMetadataBaseSchema.extend({
@@ -361,9 +363,15 @@ export const ExecutionMetadataSchema = z.union([
   ExecutionMetadataBaseSchema.extend({
     version: z.union([z.literal(1), z.literal(2), z.literal(3)]),
   }),
-  // Forward-compatible fallback for any other version.
+  // Forward-compatible fallback for any *unknown* future version only.
+  // Known versions are excluded so a malformed known-version payload (e.g. a V4
+  // with a bad `contracts` array) fails validation loudly here instead of being
+  // silently accepted and stripped — and so `version === 4` reliably narrows to
+  // the typed V4 branch above.
   ExecutionMetadataBaseSchema.extend({
-    version: z.number(),
+    version: z.number().refine((v) => !KNOWN_METADATA_VERSIONS.has(v), {
+      message: "expected a typed metadata version branch",
+    }),
   }),
 ])
 

--- a/packages/near-kit/src/core/rpc/rpc-schemas.ts
+++ b/packages/near-kit/src/core/rpc/rpc-schemas.ts
@@ -321,12 +321,51 @@ export const GasProfileEntrySchema = z
   .catchall(z.any())
 
 /**
- * Execution metadata
+ * The contract attached to a receiver account immediately before an action ran,
+ * as reported per-action by ExecutionMetadata V4.
+ *
+ * Externally tagged by contract kind:
+ * - `{ local }` - a contract deployed directly on the account (code hash)
+ * - `{ global_hash }` - a global contract referenced by its code hash
+ * - `{ global_account_id }` - a global contract referenced by the account that published it
+ *
+ * A `null` entry means the account had no contract (e.g. no code, or it did not
+ * yet exist) for that action.
  */
-export const ExecutionMetadataSchema = z.object({
-  version: z.number(),
+export const AccountContractSchema = z.union([
+  z.object({ local: z.string() }),
+  z.object({ global_hash: z.string() }),
+  z.object({ global_account_id: z.string() }),
+])
+
+const ExecutionMetadataBaseSchema = z.object({
   gas_profile: z.array(GasProfileEntrySchema).nullable().optional(),
 })
+
+/**
+ * Execution metadata, discriminated by `version`.
+ *
+ * V1-V3 carry only the gas profile. V4 (nearcore 2.13+) additionally exposes
+ * `contracts`: one entry per action in the receipt, recording the contract
+ * attached to the receiver account immediately before that action ran (or
+ * `null` when none). Unknown future versions fall back to the base shape so
+ * parsing never throws on a newer node.
+ */
+export const ExecutionMetadataSchema = z.union([
+  // V4: typed per-action contracts.
+  ExecutionMetadataBaseSchema.extend({
+    version: z.literal(4),
+    contracts: z.array(AccountContractSchema.nullable()).nullable().optional(),
+  }),
+  // V1-V3: gas profile only, no contracts field.
+  ExecutionMetadataBaseSchema.extend({
+    version: z.union([z.literal(1), z.literal(2), z.literal(3)]),
+  }),
+  // Forward-compatible fallback for any other version.
+  ExecutionMetadataBaseSchema.extend({
+    version: z.number(),
+  }),
+])
 
 /**
  * Execution outcome
@@ -642,6 +681,7 @@ export type RpcErrorResponse = z.infer<typeof RpcErrorResponseSchema>
 export type TxExecutionStatus = z.infer<typeof TxExecutionStatusSchema>
 export type ExecutionStatus = z.infer<typeof ExecutionStatusSchema>
 export type ExecutionMetadata = z.infer<typeof ExecutionMetadataSchema>
+export type AccountContract = z.infer<typeof AccountContractSchema>
 export type ExecutionOutcome = z.infer<typeof ExecutionOutcomeSchema>
 export type MerklePathItem = z.infer<typeof MerklePathItemSchema>
 export type ExecutionOutcomeWithId = z.infer<

--- a/packages/near-kit/src/core/types.ts
+++ b/packages/near-kit/src/core/types.ts
@@ -212,6 +212,7 @@ export interface SignedTransaction {
  * @see {@link https://docs.near.org/api/rpc/transactions NEAR RPC Transaction Documentation}
  */
 export type {
+  AccountContract,
   ExecutionMetadata,
   ExecutionOutcome,
   ExecutionOutcomeWithId,

--- a/packages/near-kit/tests/unit/execution-metadata-v4.test.ts
+++ b/packages/near-kit/tests/unit/execution-metadata-v4.test.ts
@@ -69,4 +69,31 @@ describe("ExecutionMetadataSchema", () => {
     })
     expect(parsed.version).toBe(5)
   })
+
+  test("rejects a malformed V4 instead of silently falling through", () => {
+    // A V4 with a bad `contracts` entry must fail loudly, not get accepted by
+    // the forward-compat fallback (which would strip `contracts`).
+    expect(() =>
+      ExecutionMetadataSchema.parse({
+        version: 4,
+        gas_profile: [],
+        contracts: [{ bogus_variant: "x" }],
+      }),
+    ).toThrow()
+  })
+
+  test("a V4 result narrows to the typed branch (contracts is available)", () => {
+    const parsed = ExecutionMetadataSchema.parse({
+      version: 4,
+      gas_profile: [],
+      contracts: [{ local: "11111111111111111111111111111111" }],
+    })
+    if (parsed.version === 4) {
+      expect(parsed.contracts?.[0]).toEqual({
+        local: "11111111111111111111111111111111",
+      })
+    } else {
+      throw new Error("expected version 4 to narrow to the V4 branch")
+    }
+  })
 })

--- a/packages/near-kit/tests/unit/execution-metadata-v4.test.ts
+++ b/packages/near-kit/tests/unit/execution-metadata-v4.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for ExecutionMetadata V4 typed `contracts` (nearcore 2.13),
+ * verifying V1-V3 back-compat is preserved.
+ */
+
+import { describe, expect, test } from "vitest"
+import { ExecutionMetadataSchema } from "../../src/core/rpc/rpc-schemas.js"
+
+describe("ExecutionMetadataSchema", () => {
+  test("parses V1 metadata (gas_profile null, no contracts)", () => {
+    const parsed = ExecutionMetadataSchema.parse({
+      version: 1,
+      gas_profile: null,
+    })
+    expect(parsed.version).toBe(1)
+    expect("contracts" in parsed).toBe(false)
+  })
+
+  test("parses V3 metadata (gas profile entries, no contracts)", () => {
+    const parsed = ExecutionMetadataSchema.parse({
+      version: 3,
+      gas_profile: [
+        { cost: "BASE", cost_category: "WASM_HOST_COST", gas_used: "123" },
+      ],
+    })
+    expect(parsed.version).toBe(3)
+    expect(parsed.gas_profile?.length).toBe(1)
+  })
+
+  test("parses V4 metadata with typed per-action contracts", () => {
+    const parsed = ExecutionMetadataSchema.parse({
+      version: 4,
+      gas_profile: [],
+      contracts: [
+        { local: "11111111111111111111111111111111" },
+        { global_hash: "22222222222222222222222222222222" },
+        { global_account_id: "factory.near" },
+        null,
+      ],
+    })
+    expect(parsed.version).toBe(4)
+    if (parsed.version === 4) {
+      expect(parsed.contracts?.length).toBe(4)
+      expect(parsed.contracts?.[0]).toEqual({
+        local: "11111111111111111111111111111111",
+      })
+      expect(parsed.contracts?.[1]).toEqual({
+        global_hash: "22222222222222222222222222222222",
+      })
+      expect(parsed.contracts?.[2]).toEqual({
+        global_account_id: "factory.near",
+      })
+      expect(parsed.contracts?.[3]).toBeNull()
+    }
+  })
+
+  test("parses V4 metadata that omits contracts (older chunk producer)", () => {
+    const parsed = ExecutionMetadataSchema.parse({
+      version: 4,
+      gas_profile: [],
+    })
+    expect(parsed.version).toBe(4)
+  })
+
+  test("does not throw on an unknown future version", () => {
+    const parsed = ExecutionMetadataSchema.parse({
+      version: 5,
+      gas_profile: null,
+    })
+    expect(parsed.version).toBe(5)
+  })
+})


### PR DESCRIPTION
## Summary

- `ExecutionMetadataSchema` is now a union discriminated on `version`. V4 (nearcore 2.13) exposes a typed `contracts` array — one entry per action recording the contract attached to the receiver before it ran (`{ local } | { global_hash } | { global_account_id } | null`).
- V1-V3 parsing is unchanged; unknown future versions still parse via a fallback.

## Test plan

- [x] `bun run build` + `bun run typecheck` + `bun run lint` clean
- [x] `bun run test:unit` (955 passing, incl. 5 new tests covering V1/V3 back-compat, V4 contracts, V4-without-contracts, and forward-compat)