### PR TITLE
feat(rpc): parse gas-key variants in RPC view responses

### DIFF
--- a/.changeset/gas-key-rpc-views.md
+++ b/.changeset/gas-key-rpc-views.md
@@ -1,0 +1,10 @@
+---
+"near-kit": minor
+---
+
+Parse gas-key variants in RPC view responses (nearcore 2.13)
+
+The RPC response schemas now accept the gas-key shapes, so reading a gas key or a transaction that touched one no longer throws:
+
+- `AccessKeyPermission` view accepts `GasKeyFunctionCall` and `GasKeyFullAccess` (each with `balance` + `num_nonces`), so `getAccessKey`/`getAccessKeys` work on gas keys.
+- The RPC action view accepts `TransferToGasKey` and `WithdrawFromGasKey`, so status-bearing transaction reads that echo those actions parse.

--- a/packages/near-kit/src/core/rpc/rpc-schemas.ts
+++ b/packages/near-kit/src/core/rpc/rpc-schemas.ts
@@ -17,13 +17,46 @@ export const FunctionCallPermissionDetailsSchema = z.object({
 })
 
 /**
- * Access key permission schema
- * Either "FullAccess" string or object with FunctionCall details
+ * Gas-key function-call permission details (nearcore 2.13).
+ *
+ * A `FunctionCall` permission that is also funded as a gas key: `balance`
+ * (yoctoNEAR string) and `num_nonces` (number of parallel nonce slots) sit
+ * alongside the usual function-call fields.
+ */
+export const GasKeyFunctionCallPermissionDetailsSchema = z.object({
+  balance: z.string(),
+  num_nonces: z.number(),
+  receiver_id: z.string(),
+  method_names: z.array(z.string()),
+  allowance: z.string().nullable().optional(),
+})
+
+/**
+ * Gas-key full-access permission details (nearcore 2.13): a funded full-access
+ * key with `balance` (yoctoNEAR string) and `num_nonces` parallel nonce slots.
+ */
+export const GasKeyFullAccessPermissionDetailsSchema = z.object({
+  balance: z.string(),
+  num_nonces: z.number(),
+})
+
+/**
+ * Access key permission schema.
+ *
+ * `"FullAccess"` (string) or one of the object variants: `FunctionCall`, or the
+ * gas-key variants added in nearcore 2.13 (`GasKeyFunctionCall` /
+ * `GasKeyFullAccess`).
  */
 export const AccessKeyPermissionSchema = z.union([
   z.literal("FullAccess"),
   z.object({
     FunctionCall: FunctionCallPermissionDetailsSchema,
+  }),
+  z.object({
+    GasKeyFunctionCall: GasKeyFunctionCallPermissionDetailsSchema,
+  }),
+  z.object({
+    GasKeyFullAccess: GasKeyFullAccessPermissionDetailsSchema,
   }),
 ])
 
@@ -418,6 +451,19 @@ export const ActionSchema = z.union([
       deposit: z.string(), // yoctoNEAR as string
     }),
   }),
+  z.object({
+    // Gas-key actions (nearcore 2.13)
+    TransferToGasKey: z.object({
+      public_key: z.string(),
+      deposit: z.string(), // yoctoNEAR as string
+    }),
+  }),
+  z.object({
+    WithdrawFromGasKey: z.object({
+      public_key: z.string(),
+      amount: z.string(), // yoctoNEAR as string
+    }),
+  }),
 ])
 
 /**
@@ -567,6 +613,12 @@ export const FinalExecutionOutcomeWithReceiptsSchema = z.intersection(
  */
 export type FunctionCallPermissionDetails = z.infer<
   typeof FunctionCallPermissionDetailsSchema
+>
+export type GasKeyFunctionCallPermissionDetails = z.infer<
+  typeof GasKeyFunctionCallPermissionDetailsSchema
+>
+export type GasKeyFullAccessPermissionDetails = z.infer<
+  typeof GasKeyFullAccessPermissionDetailsSchema
 >
 export type AccessKeyPermission = z.infer<typeof AccessKeyPermissionSchema>
 export type ViewFunctionCallResult = z.infer<

--- a/packages/near-kit/src/core/types.ts
+++ b/packages/near-kit/src/core/types.ts
@@ -120,6 +120,8 @@ export type Signer = (message: Uint8Array) => Promise<Signature>
 export type {
   AccessKeyPermission,
   FunctionCallPermissionDetails,
+  GasKeyFullAccessPermissionDetails,
+  GasKeyFunctionCallPermissionDetails,
 } from "./rpc/rpc-schemas.js"
 
 // ==================== Transaction Types ====================

--- a/packages/near-kit/tests/unit/gas-key-views.test.ts
+++ b/packages/near-kit/tests/unit/gas-key-views.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for the gas-key RPC view schemas (nearcore 2.13): the
+ * AccessKeyPermission gas-key variants and the gas-key ActionView variants.
+ */
+
+import { describe, expect, test } from "vitest"
+import {
+  AccessKeyPermissionSchema,
+  ActionSchema as RpcActionSchema,
+} from "../../src/core/rpc/rpc-schemas.js"
+
+describe("AccessKeyPermissionSchema (gas keys)", () => {
+  test("still parses FullAccess and FunctionCall", () => {
+    expect(AccessKeyPermissionSchema.parse("FullAccess")).toBe("FullAccess")
+    const fc = AccessKeyPermissionSchema.parse({
+      FunctionCall: {
+        receiver_id: "app.near",
+        method_names: ["go"],
+        allowance: "1000",
+      },
+    })
+    expect(fc).toHaveProperty("FunctionCall")
+  })
+
+  test("parses GasKeyFullAccess", () => {
+    const parsed = AccessKeyPermissionSchema.parse({
+      GasKeyFullAccess: { balance: "5000000000000000000000000", num_nonces: 4 },
+    })
+    expect(parsed).toEqual({
+      GasKeyFullAccess: { balance: "5000000000000000000000000", num_nonces: 4 },
+    })
+  })
+
+  test("parses GasKeyFunctionCall (with and without allowance)", () => {
+    const withAllowance = AccessKeyPermissionSchema.parse({
+      GasKeyFunctionCall: {
+        balance: "1000",
+        num_nonces: 8,
+        receiver_id: "app.near",
+        method_names: ["a", "b"],
+        allowance: "250",
+      },
+    })
+    expect(withAllowance).toHaveProperty("GasKeyFunctionCall")
+
+    const noAllowance = AccessKeyPermissionSchema.parse({
+      GasKeyFunctionCall: {
+        balance: "1000",
+        num_nonces: 8,
+        receiver_id: "app.near",
+        method_names: [],
+      },
+    })
+    expect(noAllowance).toHaveProperty("GasKeyFunctionCall")
+  })
+})
+
+describe("RpcActionSchema (gas-key actions)", () => {
+  test("parses TransferToGasKey", () => {
+    const parsed = RpcActionSchema.parse({
+      TransferToGasKey: { public_key: "ed25519:abc", deposit: "100" },
+    })
+    expect(parsed).toEqual({
+      TransferToGasKey: { public_key: "ed25519:abc", deposit: "100" },
+    })
+  })
+
+  test("parses WithdrawFromGasKey", () => {
+    const parsed = RpcActionSchema.parse({
+      WithdrawFromGasKey: { public_key: "ed25519:abc", amount: "50" },
+    })
+    expect(parsed).toEqual({
+      WithdrawFromGasKey: { public_key: "ed25519:abc", amount: "50" },
+    })
+  })
+
+  test("still parses a classic action (Transfer)", () => {
+    const parsed = RpcActionSchema.parse({ Transfer: { deposit: "1" } })
+    expect(parsed).toEqual({ Transfer: { deposit: "1" } })
+  })
+})


### PR DESCRIPTION
## Summary

- RPC response schemas now accept the gas-key shapes from nearcore 2.13, so reading a gas key or a tx that touched one no longer throws a zod error.
- `AccessKeyPermission` view accepts `GasKeyFunctionCall` / `GasKeyFullAccess` (`balance` + `num_nonces`), so `getAccessKey` / `getAccessKeys` work on gas keys.
- The RPC action view accepts `TransferToGasKey` / `WithdrawFromGasKey`, so status-bearing transaction reads that echo those actions parse.

## Notes

- Fills the view-side counterpart to the gas-key actions/permissions added in #196 (those are borsh request-side; this is the zod response-side, which lives in this track's file).

## Test plan

- [x] `bun run build` + `bun run typecheck` + `bun run lint` clean
- [x] `bun run test:unit` (956 passing, incl. 6 new tests covering each gas-key permission and action view shape + back-compat)