### PR TITLE
test: harden flaky near-kit tests for deterministic CI

### DIFF
--- a/.changeset/harden-flaky-tests.md
+++ b/.changeset/harden-flaky-tests.md
@@ -1,0 +1,5 @@
+---
+"near-kit": patch
+---
+
+Harden flaky tests: make RPC-init unit tests assert configured URL without live network, raise tight 10s integration-test timeouts to the 60s global, and make the CI codecov upload non-fatal and conditional.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,10 @@ jobs:
         run: bun run test
 
       - name: Upload coverage to Codecov
+        if: hashFiles('packages/near-kit/coverage/lcov.info') != ''
+        continue-on-error: true
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/near-kit/coverage/lcov.info
+          fail_ci_if_error: false

--- a/packages/near-kit/tests/integration/error-handling.test.ts
+++ b/packages/near-kit/tests/integration/error-handling.test.ts
@@ -37,7 +37,7 @@ describe("Error Handling - Account Errors", () => {
       expect(accountError.message).toContain(nonExistentAccount)
       console.log(`✓ AccountDoesNotExistError: ${accountError.message}`)
     }
-  }, 10000)
+  })
 
   test("should successfully get existing account", async () => {
     const account = await rpc.getAccount("near")
@@ -45,7 +45,7 @@ describe("Error Handling - Account Errors", () => {
     expect(account.amount).toBeDefined()
     expect(account.storage_usage).toBeGreaterThan(0)
     console.log(`✓ Successfully retrieved account 'near'`)
-  }, 10000)
+  })
 })
 
 describe("Error Handling - Access Key Errors", () => {
@@ -73,7 +73,7 @@ describe("Error Handling - Access Key Errors", () => {
       expect(keyError.message).toContain(accountId)
       console.log(`✓ AccessKeyDoesNotExistError: ${keyError.message}`)
     }
-  }, 10000)
+  })
 
   test("should successfully get existing access key", async () => {
     // First get the list of access keys for an account
@@ -99,7 +99,7 @@ describe("Error Handling - Access Key Errors", () => {
     expect(accessKey.nonce).toBeDefined()
     expect(accessKey.permission).toBeDefined()
     console.log(`✓ Successfully retrieved access key for '${accountId}'`)
-  }, 10000)
+  })
 })
 
 describe("Error Handling - Function Call Errors", () => {
@@ -129,7 +129,7 @@ describe("Error Handling - Function Call Errors", () => {
       expect(funcError.panic).toContain("MethodNotFound")
       console.log(`✓ FunctionCallError: ${funcError.message}`)
     }
-  }, 10000)
+  })
 
   test("should throw FunctionCallError for method call on non-contract account", async () => {
     const accountId = "near"
@@ -150,7 +150,7 @@ describe("Error Handling - Function Call Errors", () => {
       expect(funcError.methodName).toBe(methodName)
       console.log(`✓ FunctionCallError for non-contract: ${funcError.message}`)
     }
-  }, 10000)
+  })
 
   test("should successfully call valid view method", async () => {
     const result = await rpc.viewFunction("wrap.near", "ft_metadata", {})
@@ -164,7 +164,7 @@ describe("Error Handling - Function Call Errors", () => {
     )
     expect(decoded.name).toBeDefined()
     console.log(`✓ Successfully called view method: ${decoded.name}`)
-  }, 10000)
+  })
 })
 
 describe("Error Handling - Network Errors", () => {

--- a/packages/near-kit/tests/integration/rpc-view-methods.test.ts
+++ b/packages/near-kit/tests/integration/rpc-view-methods.test.ts
@@ -64,7 +64,7 @@ describe("RPC View Methods - Mainnet", () => {
     console.log(
       `✓ Mainnet status: chain=${status.chain_id}, height=${status.sync_info.latest_block_height}, validators=${status.validators.length}`,
     )
-  }, 10000) // 10 second timeout
+  })
 
   test("getBlock should return block with default finality", async () => {
     const block = await rpc.getBlock()
@@ -79,7 +79,7 @@ describe("RPC View Methods - Mainnet", () => {
     console.log(
       `✓ Block (final): height=${block.header.height}, hash=${block.header.hash.slice(0, 8)}...`,
     )
-  }, 10000)
+  })
 
   test("getBlock should accept finality parameter", async () => {
     const block = await rpc.getBlock({ finality: "optimistic" })
@@ -89,7 +89,7 @@ describe("RPC View Methods - Mainnet", () => {
     expect(block.header.height).toBeGreaterThan(0)
 
     console.log(`✓ Block (optimistic): height=${block.header.height}`)
-  }, 10000)
+  })
 
   test("getBlock should accept blockId parameter", async () => {
     // First get the current final block to get a valid height
@@ -104,7 +104,7 @@ describe("RPC View Methods - Mainnet", () => {
     console.log(
       `✓ Block (by height ${targetHeight}): hash=${block.header.hash.slice(0, 8)}...`,
     )
-  }, 10000)
+  })
 
   test("getAccount should return account info for known account", async () => {
     const account: AccountView = await rpc.getAccount(MAINNET_ACCOUNT)
@@ -125,7 +125,7 @@ describe("RPC View Methods - Mainnet", () => {
     console.log(
       `✓ Account '${MAINNET_ACCOUNT}': balance=${account.amount} yoctoNEAR, storage=${account.storage_usage} bytes`,
     )
-  }, 10000)
+  })
 
   test("getGasPrice should return current gas price", async () => {
     const gasPrice: GasPriceResponse = await rpc.getGasPrice()
@@ -139,7 +139,7 @@ describe("RPC View Methods - Mainnet", () => {
     expect(price).toBeGreaterThan(0n)
 
     console.log(`✓ Gas price: ${gasPrice.gas_price} yoctoNEAR`)
-  }, 10000)
+  })
 
   test("viewFunction should call contract view method", async () => {
     const result: ViewFunctionCallResult = await rpc.viewFunction(
@@ -167,7 +167,7 @@ describe("RPC View Methods - Mainnet", () => {
     console.log(
       `✓ View call to ${WRAP_NEAR_CONTRACT}.ft_metadata(): ${decoded.name}`,
     )
-  }, 10000)
+  })
 })
 
 describe("RPC View Methods - Testnet", () => {
@@ -190,7 +190,7 @@ describe("RPC View Methods - Testnet", () => {
     console.log(
       `✓ Testnet status: chain=${status.chain_id}, height=${status.sync_info.latest_block_height}`,
     )
-  }, 10000)
+  })
 
   test("getAccount should return account info for known account", async () => {
     const account: AccountView = await rpc.getAccount(TESTNET_ACCOUNT)
@@ -204,7 +204,7 @@ describe("RPC View Methods - Testnet", () => {
     console.log(
       `✓ Testnet account '${TESTNET_ACCOUNT}': balance=${account.amount} yoctoNEAR`,
     )
-  }, 10000)
+  })
 
   test("getGasPrice should return current gas price", async () => {
     const gasPrice: GasPriceResponse = await rpc.getGasPrice()
@@ -217,7 +217,7 @@ describe("RPC View Methods - Testnet", () => {
     expect(price).toBeGreaterThan(0n)
 
     console.log(`✓ Testnet gas price: ${gasPrice.gas_price} yoctoNEAR`)
-  }, 10000)
+  })
 })
 
 describe("RPC Error Handling", () => {
@@ -242,7 +242,7 @@ describe("RPC Error Handling", () => {
         `✓ Correctly handled non-existent account error: ${accountError.message}`,
       )
     }
-  }, 10000)
+  })
 
   test("should handle invalid contract method call", async () => {
     try {
@@ -258,5 +258,5 @@ describe("RPC Error Handling", () => {
       expect(error).toBeDefined()
       console.log(`✓ Correctly handled invalid method call error`)
     }
-  }, 10000)
+  })
 })

--- a/packages/near-kit/tests/unit/near-constructor.test.ts
+++ b/packages/near-kit/tests/unit/near-constructor.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, expect, test } from "vitest"
+import { NETWORK_PRESETS } from "../../src/core/constants.js"
 import { Near } from "../../src/core/near.js"
 import type { Signer } from "../../src/core/types.js"
 import { KeyType } from "../../src/core/types.js"
@@ -13,25 +14,22 @@ import { InMemoryKeyStore } from "../../src/keys/index.js"
 import { generateKey } from "../../src/utils/key.js"
 
 describe("Near Constructor - RPC Initialization", () => {
-  test("_initializeRpc: uses default mainnet RPC URL", async () => {
+  test("_initializeRpc: uses default mainnet RPC URL", () => {
     const near = new Near({ network: "mainnet" })
-    const status = await near.getStatus()
-    expect(status.chain_id).toBe("mainnet")
+    expect(near.rpc["url"]).toBe(NETWORK_PRESETS.mainnet.rpcUrl)
   })
 
-  test("_initializeRpc: uses custom RPC URL", async () => {
+  test("_initializeRpc: uses custom RPC URL", () => {
     const near = new Near({
       network: "mainnet",
       rpcUrl: "https://rpc.mainnet.near.org",
     })
-    const status = await near.getStatus()
-    expect(status.chain_id).toBe("mainnet")
+    expect(near.rpc["url"]).toBe("https://rpc.mainnet.near.org")
   })
 
-  test("_initializeRpc: uses testnet RPC URL", async () => {
+  test("_initializeRpc: uses testnet RPC URL", () => {
     const near = new Near({ network: "testnet" })
-    const status = await near.getStatus()
-    expect(status.chain_id).toBe("testnet")
+    expect(near.rpc["url"]).toBe(NETWORK_PRESETS.testnet.rpcUrl)
   })
 
   test("_initializeRpc: accepts custom headers and retry config", () => {


### PR DESCRIPTION
## Cause

Three sources of non-deterministic CI:

- Three `_initializeRpc` unit tests made real public-RPC calls (`await near.getStatus()`) and flaked with HTTP 429.
- RPC-backed integration tests (`error-handling.test.ts`, `rpc-view-methods.test.ts`) capped each test at a tight 10s, overriding the 60s global; slow/rate-limited RPC blew past 10s.
- The `tests` CI job runs `vitest run` (no coverage), so `coverage/lcov.info` is never produced; the Codecov step then errored "No coverage reports found" and non-deterministically failed the job.

## Change

- `near-constructor.test.ts`: rewrite the three RPC-init tests to synchronously assert the configured endpoint via `near.rpc["url"]` against `NETWORK_PRESETS` — no network.
- `error-handling.test.ts` / `rpc-view-methods.test.ts`: remove the per-test `, 10000` overrides so they inherit the 60s global; keep the legit 30s/60s ones. Timeout-only changes.
- `ci.yml`: guard the Codecov step with `hashFiles(...) != ''` and add `continue-on-error: true` + `fail_ci_if_error: false` so it can never fail the job. `lint-and-typecheck` untouched.
- Changeset: `near-kit` patch.

## How tested

- `bun run build`, `bun run typecheck`, `bun run lint` clean (only the pre-existing biome schema-version info).
- `cd packages/near-kit && bun run test:unit`: 37 files / 1041 tests pass in ~4s; the rewritten RPC-init tests run instantly with no network.
- `bun run vitest run tests/integration/error-handling.test.ts`: 9/9 pass (~33s total — confirming why a 10s per-test cap flaked).