### PR TITLE
test: run RPC integration tests against sandbox instead of live RPC

### DIFF
--- a/.changeset/deterministic-rpc-tests.md
+++ b/.changeset/deterministic-rpc-tests.md
@@ -1,0 +1,5 @@
+---
+"near-kit": patch
+---
+
+Make RPC error-handling and view-method integration tests deterministic by running them against the local sandbox instead of live public RPC.

--- a/packages/near-kit/tests/integration/error-handling.test.ts
+++ b/packages/near-kit/tests/integration/error-handling.test.ts
@@ -207,8 +207,14 @@ describe("Error Handling - Function Call Errors", () => {
 })
 
 describe("Error Handling - Network Errors", () => {
-  // Deterministically-unreachable local endpoint (connection refused, instant).
-  const invalidRpc = new RpcClient("http://127.0.0.1:1")
+  // Deterministically-unreachable local endpoint: the connection is refused on
+  // every attempt. ECONNREFUSED maps to a *retryable* NetworkError, so retries
+  // are disabled here (maxRetries: 0) — otherwise each getStatus() burns the
+  // full backoff budget (~15s) and this suite would take ~30s. With retries off
+  // it fails in milliseconds while still exercising the NetworkError path.
+  const invalidRpc = new RpcClient("http://127.0.0.1:1", undefined, {
+    maxRetries: 0,
+  })
 
   test("should throw NetworkError for unreachable RPC endpoint", async () => {
     await expect(async () => {

--- a/packages/near-kit/tests/integration/error-handling.test.ts
+++ b/packages/near-kit/tests/integration/error-handling.test.ts
@@ -1,10 +1,14 @@
 /**
  * Integration tests for typed error handling
  *
- * Tests various error scenarios to ensure proper typed errors are thrown
+ * Tests various error scenarios to ensure proper typed errors are thrown.
+ * Runs against a local Sandbox (deterministic) rather than live public RPC.
  */
 
-import { describe, expect, test } from "vitest"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+import { Near } from "../../src/core/near.js"
 import { RpcClient } from "../../src/core/rpc/rpc.js"
 import {
   AccessKeyDoesNotExistError,
@@ -12,14 +16,52 @@ import {
   FunctionCallError,
   NetworkError,
 } from "../../src/errors/index.js"
+import { Sandbox } from "../../src/sandbox/sandbox.js"
+import { generateKey } from "../../src/utils/key.js"
 
-const MAINNET_RPC = "https://free.rpc.fastnear.com"
+let sandbox: Sandbox
+let rpc: RpcClient
+let contractId: string
+
+beforeAll(async () => {
+  sandbox = await Sandbox.start()
+  const near = new Near({
+    network: sandbox,
+    keyStore: {
+      [sandbox.rootAccount.id]: sandbox.rootAccount.secretKey,
+    },
+  })
+
+  // Deploy guestbook contract so view-method scenarios have a real contract.
+  contractId = `contract-${Date.now()}.${sandbox.rootAccount.id}`
+  const contractWasm = readFileSync(
+    resolve(__dirname, "../contracts/guestbook.wasm"),
+  )
+  const contractKey = generateKey()
+  await near
+    .transaction(sandbox.rootAccount.id)
+    .createAccount(contractId)
+    .transfer(contractId, "10 NEAR")
+    .addKey(contractKey.publicKey.toString(), { type: "fullAccess" })
+    .deployContract(contractId, contractWasm)
+    .send({ waitUntil: "FINAL" })
+
+  rpc = new RpcClient(sandbox.rpcUrl)
+
+  console.log(`✓ Sandbox started: ${sandbox.rpcUrl}`)
+  console.log(`✓ Contract deployed: ${contractId}`)
+}, 120000)
+
+afterAll(async () => {
+  if (sandbox) {
+    await sandbox.stop()
+    console.log("✓ Sandbox stopped")
+  }
+})
 
 describe("Error Handling - Account Errors", () => {
-  const rpc = new RpcClient(MAINNET_RPC)
-
   test("should throw AccountDoesNotExistError for non-existent account", async () => {
-    const nonExistentAccount = "this-account-does-not-exist-xyz-12345.near"
+    const nonExistentAccount = `nope-${Date.now()}.${sandbox.rootAccount.id}`
 
     await expect(async () => {
       await rpc.getAccount(nonExistentAccount)
@@ -40,19 +82,17 @@ describe("Error Handling - Account Errors", () => {
   })
 
   test("should successfully get existing account", async () => {
-    const account = await rpc.getAccount("near")
+    const account = await rpc.getAccount(sandbox.rootAccount.id)
     expect(account).toBeDefined()
     expect(account.amount).toBeDefined()
-    expect(account.storage_usage).toBeGreaterThan(0)
-    console.log(`✓ Successfully retrieved account 'near'`)
+    expect(account.storage_usage).toBeGreaterThanOrEqual(0)
+    console.log(`✓ Successfully retrieved account '${sandbox.rootAccount.id}'`)
   })
 })
 
 describe("Error Handling - Access Key Errors", () => {
-  const rpc = new RpcClient(MAINNET_RPC)
-
   test("should throw AccessKeyDoesNotExistError for non-existent access key", async () => {
-    const accountId = "near"
+    const accountId = sandbox.rootAccount.id
     const fakePublicKey = "ed25519:He7QeRuwizNEhzeKNn2CLdCKfzkH6KLSaFKvJLYtnrFa"
 
     await expect(async () => {
@@ -76,8 +116,8 @@ describe("Error Handling - Access Key Errors", () => {
   })
 
   test("should successfully get existing access key", async () => {
-    // First get the list of access keys for an account
-    const accountId = "near"
+    // First get the list of access keys for the root account
+    const accountId = sandbox.rootAccount.id
     const listResult = await rpc.call<{
       keys: Array<{ public_key: string }>
     }>("query", {
@@ -103,10 +143,7 @@ describe("Error Handling - Access Key Errors", () => {
 })
 
 describe("Error Handling - Function Call Errors", () => {
-  const rpc = new RpcClient(MAINNET_RPC)
-
   test("should throw FunctionCallError for non-existent method", async () => {
-    const contractId = "wrap.near"
     const methodName = "this_method_does_not_exist_xyz"
 
     await expect(async () => {
@@ -132,7 +169,8 @@ describe("Error Handling - Function Call Errors", () => {
   })
 
   test("should throw FunctionCallError for method call on non-contract account", async () => {
-    const accountId = "near"
+    // The sandbox root account has no contract deployed.
+    const accountId = sandbox.rootAccount.id
     const methodName = "some_method"
 
     await expect(async () => {
@@ -153,22 +191,24 @@ describe("Error Handling - Function Call Errors", () => {
   })
 
   test("should successfully call valid view method", async () => {
-    const result = await rpc.viewFunction("wrap.near", "ft_metadata", {})
+    const result = await rpc.viewFunction(contractId, "total_messages", {})
     expect(result).toBeDefined()
     expect(result.result).toBeDefined()
     expect(Array.isArray(result.result)).toBe(true)
 
-    // Decode result
+    // Decode result - total_messages() returns a number.
     const decoded = JSON.parse(
       new TextDecoder().decode(new Uint8Array(result.result)),
     )
-    expect(decoded.name).toBeDefined()
-    console.log(`✓ Successfully called view method: ${decoded.name}`)
+    expect(typeof decoded).toBe("number")
+    expect(decoded).toBe(0)
+    console.log(`✓ Successfully called view method: total_messages=${decoded}`)
   })
 })
 
 describe("Error Handling - Network Errors", () => {
-  const invalidRpc = new RpcClient("https://invalid-rpc-endpoint-xyz.near.org")
+  // Deterministically-unreachable local endpoint (connection refused, instant).
+  const invalidRpc = new RpcClient("http://127.0.0.1:1")
 
   test("should throw NetworkError for unreachable RPC endpoint", async () => {
     await expect(async () => {
@@ -186,31 +226,29 @@ describe("Error Handling - Network Errors", () => {
       expect(netError.retryable).toBe(true)
       console.log(`✓ NetworkError: ${netError.message}`)
     }
-  }, 60000)
+  })
 })
 
 describe("Error Handling - Error Properties", () => {
-  const rpc = new RpcClient(MAINNET_RPC)
-
   test("all error types should extend NearError", async () => {
     const testCases = [
       {
         name: "AccountDoesNotExistError",
         test: async () =>
-          await rpc.getAccount("nonexistent-account-xyz-12345.near"),
+          await rpc.getAccount(`nope-${Date.now()}.${sandbox.rootAccount.id}`),
       },
       {
         name: "AccessKeyDoesNotExistError",
         test: async () =>
           await rpc.getAccessKey(
-            "near",
+            sandbox.rootAccount.id,
             "ed25519:He7QeRuwizNEhzeKNn2CLdCKfzkH6KLSaFKvJLYtnrFa",
           ),
       },
       {
         name: "FunctionCallError",
         test: async () =>
-          await rpc.viewFunction("wrap.near", "nonexistent_method_xyz", {}),
+          await rpc.viewFunction(contractId, "nonexistent_method_xyz", {}),
       },
     ]
 
@@ -228,5 +266,5 @@ describe("Error Handling - Error Properties", () => {
         )
       }
     }
-  }, 30000)
+  })
 })

--- a/packages/near-kit/tests/integration/rpc-view-methods.test.ts
+++ b/packages/near-kit/tests/integration/rpc-view-methods.test.ts
@@ -1,11 +1,15 @@
 /**
- * Integration tests for RPC view methods against real NEAR RPC endpoints
+ * Integration tests for RPC view methods.
  *
- * These tests make actual network calls to NEAR mainnet and testnet RPCs.
- * They test read-only operations that don't require signing or gas.
+ * These tests run against a local Sandbox (deterministic) rather than live
+ * public RPC. They exercise read-only operations that don't require signing or
+ * gas, plus a couple of error paths.
  */
 
-import { describe, expect, test } from "vitest"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+import { Near } from "../../src/core/near.js"
 import { RpcClient } from "../../src/core/rpc/rpc.js"
 import type {
   AccountView,
@@ -14,27 +18,57 @@ import type {
   ViewFunctionCallResult,
 } from "../../src/core/types.js"
 import { AccountDoesNotExistError } from "../../src/errors/index.js"
+import { Sandbox } from "../../src/sandbox/sandbox.js"
+import { generateKey } from "../../src/utils/key.js"
 
-// Use the new FastNEAR endpoints
-const MAINNET_RPC = "https://free.rpc.fastnear.com"
-const TESTNET_RPC = "https://rpc.testnet.fastnear.com"
+let sandbox: Sandbox
+let rpc: RpcClient
+let contractId: string
 
-// Well-known accounts that should exist
-const MAINNET_ACCOUNT = "near"
-const TESTNET_ACCOUNT = "testnet"
+beforeAll(async () => {
+  sandbox = await Sandbox.start()
+  const near = new Near({
+    network: sandbox,
+    keyStore: {
+      [sandbox.rootAccount.id]: sandbox.rootAccount.secretKey,
+    },
+  })
 
-// Well-known contract for testing view calls
-const WRAP_NEAR_CONTRACT = "wrap.near" // Wrapped NEAR contract on mainnet
+  // Deploy guestbook contract for view-call coverage.
+  contractId = `contract-${Date.now()}.${sandbox.rootAccount.id}`
+  const contractWasm = readFileSync(
+    resolve(__dirname, "../contracts/guestbook.wasm"),
+  )
+  const contractKey = generateKey()
+  await near
+    .transaction(sandbox.rootAccount.id)
+    .createAccount(contractId)
+    .transfer(contractId, "10 NEAR")
+    .addKey(contractKey.publicKey.toString(), { type: "fullAccess" })
+    .deployContract(contractId, contractWasm)
+    .send({ waitUntil: "FINAL" })
 
-describe("RPC View Methods - Mainnet", () => {
-  const rpc = new RpcClient(MAINNET_RPC)
+  rpc = new RpcClient(sandbox.rpcUrl)
 
+  console.log(`✓ Sandbox started: ${sandbox.rpcUrl}`)
+  console.log(`✓ Contract deployed: ${contractId}`)
+}, 120000)
+
+afterAll(async () => {
+  if (sandbox) {
+    await sandbox.stop()
+    console.log("✓ Sandbox stopped")
+  }
+})
+
+describe("RPC View Methods (sandbox)", () => {
   test("getStatus should return network status", async () => {
     const status: StatusResponse = await rpc.getStatus()
 
     // Verify response structure
     expect(status).toBeDefined()
-    expect(status.chain_id).toBe("mainnet")
+    expect(typeof status.chain_id).toBe("string")
+    expect(status.chain_id).toBe(sandbox.networkId)
     expect(status.genesis_hash).toBeDefined()
     expect(status.version).toBeDefined()
     expect(status.version.version).toBeDefined()
@@ -62,7 +96,7 @@ describe("RPC View Methods - Mainnet", () => {
     expect(typeof status.sync_info.syncing).toBe("boolean")
 
     console.log(
-      `✓ Mainnet status: chain=${status.chain_id}, height=${status.sync_info.latest_block_height}, validators=${status.validators.length}`,
+      `✓ Status: chain=${status.chain_id}, height=${status.sync_info.latest_block_height}, validators=${status.validators.length}`,
     )
   })
 
@@ -92,9 +126,10 @@ describe("RPC View Methods - Mainnet", () => {
   })
 
   test("getBlock should accept blockId parameter", async () => {
-    // First get the current final block to get a valid height
+    // First get the current final block to get a valid height. Guard against
+    // underflow on a very fresh sandbox by clamping to height 1.
     const finalBlock = await rpc.getBlock({ finality: "final" })
-    const targetHeight = finalBlock.header.height - 5 // Get a block 5 behind
+    const targetHeight = Math.max(1, finalBlock.header.height - 1)
 
     const block = await rpc.getBlock({ blockId: targetHeight })
 
@@ -107,14 +142,14 @@ describe("RPC View Methods - Mainnet", () => {
   })
 
   test("getAccount should return account info for known account", async () => {
-    const account: AccountView = await rpc.getAccount(MAINNET_ACCOUNT)
+    const account: AccountView = await rpc.getAccount(sandbox.rootAccount.id)
 
     // Verify response structure
     expect(account).toBeDefined()
     expect(account.amount).toBeDefined()
     expect(account.locked).toBeDefined()
     expect(account.code_hash).toBeDefined()
-    expect(account.storage_usage).toBeGreaterThan(0)
+    expect(account.storage_usage).toBeGreaterThanOrEqual(0)
     expect(account.block_height).toBeGreaterThan(0)
     expect(account.block_hash).toBeDefined()
 
@@ -123,7 +158,7 @@ describe("RPC View Methods - Mainnet", () => {
     expect(BigInt(account.locked)).toBeGreaterThanOrEqual(0n)
 
     console.log(
-      `✓ Account '${MAINNET_ACCOUNT}': balance=${account.amount} yoctoNEAR, storage=${account.storage_usage} bytes`,
+      `✓ Account '${sandbox.rootAccount.id}': balance=${account.amount} yoctoNEAR, storage=${account.storage_usage} bytes`,
     )
   })
 
@@ -143,8 +178,8 @@ describe("RPC View Methods - Mainnet", () => {
 
   test("viewFunction should call contract view method", async () => {
     const result: ViewFunctionCallResult = await rpc.viewFunction(
-      WRAP_NEAR_CONTRACT,
-      "ft_metadata",
+      contractId,
+      "total_messages",
       {},
     )
 
@@ -157,75 +192,19 @@ describe("RPC View Methods - Mainnet", () => {
     expect(result.block_height).toBeGreaterThan(0)
     expect(result.block_hash).toBeDefined()
 
-    // Decode the result to verify it's valid JSON
+    // Decode the result - total_messages() returns a number.
     const decoded = JSON.parse(
       new TextDecoder().decode(new Uint8Array(result.result)),
     )
-    expect(decoded).toBeDefined()
-    expect(decoded.name).toBeDefined() // FT metadata should have name field
+    expect(typeof decoded).toBe("number")
 
-    console.log(
-      `✓ View call to ${WRAP_NEAR_CONTRACT}.ft_metadata(): ${decoded.name}`,
-    )
-  })
-})
-
-describe("RPC View Methods - Testnet", () => {
-  const rpc = new RpcClient(TESTNET_RPC)
-
-  test("getStatus should return network status", async () => {
-    const status: StatusResponse = await rpc.getStatus()
-
-    // Verify response structure
-    expect(status).toBeDefined()
-    expect(status.chain_id).toBe("testnet")
-    expect(status.version).toBeDefined()
-    expect(status.protocol_version).toBeGreaterThan(0)
-
-    // Verify sync info
-    expect(status.sync_info).toBeDefined()
-    expect(status.sync_info.latest_block_hash).toBeDefined()
-    expect(status.sync_info.latest_block_height).toBeGreaterThan(0)
-
-    console.log(
-      `✓ Testnet status: chain=${status.chain_id}, height=${status.sync_info.latest_block_height}`,
-    )
-  })
-
-  test("getAccount should return account info for known account", async () => {
-    const account: AccountView = await rpc.getAccount(TESTNET_ACCOUNT)
-
-    // Verify response structure
-    expect(account).toBeDefined()
-    expect(account.amount).toBeDefined()
-    expect(account.storage_usage).toBeGreaterThan(0)
-    expect(account.block_height).toBeGreaterThan(0)
-
-    console.log(
-      `✓ Testnet account '${TESTNET_ACCOUNT}': balance=${account.amount} yoctoNEAR`,
-    )
-  })
-
-  test("getGasPrice should return current gas price", async () => {
-    const gasPrice: GasPriceResponse = await rpc.getGasPrice()
-
-    // Verify response structure
-    expect(gasPrice).toBeDefined()
-    expect(gasPrice.gas_price).toBeDefined()
-
-    const price = BigInt(gasPrice.gas_price)
-    expect(price).toBeGreaterThan(0n)
-
-    console.log(`✓ Testnet gas price: ${gasPrice.gas_price} yoctoNEAR`)
+    console.log(`✓ View call to ${contractId}.total_messages(): ${decoded}`)
   })
 })
 
 describe("RPC Error Handling", () => {
-  const rpc = new RpcClient(MAINNET_RPC)
-
   test("should handle non-existent account", async () => {
-    const nonExistentAccount =
-      "this-account-definitely-does-not-exist-12345.near"
+    const nonExistentAccount = `nope-${Date.now()}.${sandbox.rootAccount.id}`
 
     try {
       await rpc.getAccount(nonExistentAccount)
@@ -246,15 +225,11 @@ describe("RPC Error Handling", () => {
 
   test("should handle invalid contract method call", async () => {
     try {
-      await rpc.viewFunction(
-        MAINNET_ACCOUNT,
-        "this_method_does_not_exist_12345",
-        {},
-      )
+      await rpc.viewFunction(contractId, "this_method_does_not_exist_12345", {})
       // Should not reach here
       expect(false).toBe(true)
     } catch (error) {
-      // Should throw a NetworkError
+      // Should throw an error (FunctionCallError for a missing method)
       expect(error).toBeDefined()
       console.log(`✓ Correctly handled invalid method call error`)
     }


### PR DESCRIPTION
## Cause

`error-handling.test.ts` and `rpc-view-methods.test.ts` hit live public RPC (free.rpc.fastnear.com, rpc.testnet.fastnear.com), which is inherently flaky (429s, latency) and depends on mainnet/testnet state.

## Change

Both suites now spin up a local `Sandbox` in `beforeAll`, deploy `guestbook.wasm` to a fresh contract account, and run all assertions against a sandbox-backed `RpcClient`:

- Account/access-key errors query non-existent subaccounts / fake keys on the sandbox root.
- Function-call errors and the valid view-method call use the deployed guestbook contract (`total_messages`).
- The `NetworkError` case hits `http://127.0.0.1:1` (connection refused, instant) instead of a public DNS name.
- The live mainnet/testnet view-method blocks are folded into a single sandbox block; `getStatus` asserts the sandbox `networkId`; `getBlock`-by-height clamps to avoid underflow on a fresh sandbox.

No live public-RPC calls remain (verified by grep).

## How tested

`bun run build`, `bun run typecheck`, `bun run lint` clean. `bun run vitest run tests/integration/error-handling.test.ts tests/integration/rpc-view-methods.test.ts` — 18/18 pass against the sandbox.