### PR TITLE
feat(nep413): support custom nonce schemes in verification

### DIFF
--- a/.changeset/custom-nonce-validation.md
+++ b/.changeset/custom-nonce-validation.md
@@ -1,0 +1,10 @@
+---
+"near-kit": minor
+---
+
+Add `nonceValidation` option to `verifyNep413Signature` for custom nonce schemes
+
+NEP-413 defines the nonce as an opaque 32-byte value; embedding a timestamp in the first 8 bytes is a near-kit convention used by `generateNonce()`. Previously, verification always interpreted the first 8 bytes as a timestamp and enforced `maxAge`, which rejected valid signatures from apps using their own nonce schemes (e.g. intents.near).
+
+- `nonceValidation: "timestamp"` (default) - existing behavior, unchanged
+- `nonceValidation: "none"` - treat the nonce as opaque bytes per the spec; no timestamp/expiry check (`maxAge` is ignored), caller is responsible for nonce validation and replay protection

--- a/docs/in-depth/message-signing.mdx
+++ b/docs/in-depth/message-signing.mdx
@@ -22,7 +22,7 @@ You **must** generate a random nonce. This ensures that a captured signature can
 import { Near, generateNonce } from "near-kit"
 import { hex } from "@scure/base"
 
-// 1. Generate a random 32-byte nonce with embedded timestamp
+// 1. Generate a random 32-byte nonce (with embedded timestamp, a near-kit convention)
 const nonce = generateNonce()
 
 // 2. Request Signature
@@ -49,7 +49,7 @@ The `signature` field is base64 encoded per the NEP-413 specification. Send it u
 
 ## 2. The Server (Backend)
 
-**Automatic Expiration:** Nonces include an embedded timestamp. Signatures older than 5 minutes are automatically rejected, limiting the replay attack window.
+**Automatic Expiration:** Nonces created with `generateNonce()` embed a timestamp in their first 8 bytes. This is a near-kit convention (NEP-413 itself treats the nonce as arbitrary bytes) that lets `verifyNep413Signature` automatically reject signatures older than 5 minutes, limiting the replay attack window.
 
 ```typescript
 import { Near, verifyNep413Signature } from "near-kit"
@@ -105,6 +105,22 @@ Cryptographic verification alone is not enough! If you do not check if the `nonc
 
 **Always store used nonces in your database (with an expiration time) and reject duplicates.**
 </Warning>
+
+## Custom Nonce Schemes
+
+NEP-413 defines the nonce as an opaque 32-byte value — the timestamp-in-the-first-8-bytes layout is just near-kit's convention. Some apps define their own nonce structure instead (for example, [intents.near](https://github.com/near/intents) uses a versioned, salted, expirable nonce).
+
+By default, `verifyNep413Signature` interprets the first 8 bytes of the nonce as a timestamp, so it will reject valid signatures that use a different scheme. Pass `nonceValidation: "none"` to treat the nonce as opaque bytes per the spec:
+
+```typescript
+const isValid = await verifyNep413Signature(signedMessage, params, {
+  near,
+  nonceValidation: "none", // skip the timestamp check; maxAge is ignored
+})
+
+// You are now responsible for nonce validation and replay protection,
+// e.g. decode the nonce per your scheme and check expiry/uniqueness yourself
+```
 
 ## Type Definition
 

--- a/packages/near-kit/src/utils/nep413.ts
+++ b/packages/near-kit/src/utils/nep413.ts
@@ -196,9 +196,10 @@ export async function verifyNep413Signature(
     } = options // Default: 5 minutes
 
     // Check timestamp expiration if the nonce follows the near-kit timestamp
-    // convention and maxAge is finite
+    // convention and maxAge is finite. Fail closed: only an explicit "none"
+    // opts out, so unexpected values keep the default replay/expiry protection.
     if (
-      nonceValidation === "timestamp" &&
+      nonceValidation !== "none" &&
       maxAge !== Infinity &&
       params.nonce.length === 32
     ) {

--- a/packages/near-kit/src/utils/nep413.ts
+++ b/packages/near-kit/src/utils/nep413.ts
@@ -101,7 +101,8 @@ export interface VerifyNep413Options {
    * Passing `Infinity` is a legacy escape hatch that skips timestamp
    * validation entirely, including the future-timestamp rejection — the same
    * effect as `nonceValidation: "none"`, which is the preferred way to opt
-   * out. `NaN` falls back to the default.
+   * out. Invalid values (non-numbers, `NaN`, negatives) fall back to the
+   * default.
    *
    * @default 300000 (5 minutes)
    */
@@ -201,9 +202,16 @@ export async function verifyNep413Signature(
       near,
     } = options // Default: 5 minutes
 
-    // NaN would make the age comparison below always false and silently
-    // disable the expiry check; fail closed by falling back to the default
-    const maxAge = Number.isNaN(rawMaxAge) ? 5 * 60 * 1000 : rawMaxAge
+    // Invalid runtime values (non-numbers, NaN, negatives — possible from
+    // plain JS callers) would silently disable or distort the expiry check;
+    // fail closed by falling back to the default. Infinity remains a valid
+    // opt-out.
+    const maxAge =
+      typeof rawMaxAge === "number" &&
+      !Number.isNaN(rawMaxAge) &&
+      rawMaxAge >= 0
+        ? rawMaxAge
+        : 5 * 60 * 1000
 
     // Check timestamp expiration if the nonce follows the near-kit timestamp
     // convention and maxAge is finite. Fail closed: only an explicit "none"

--- a/packages/near-kit/src/utils/nep413.ts
+++ b/packages/near-kit/src/utils/nep413.ts
@@ -208,6 +208,8 @@ export async function verifyNep413Signature(
     // Check timestamp expiration if the nonce follows the near-kit timestamp
     // convention and maxAge is finite. Fail closed: only an explicit "none"
     // opts out, so unexpected values keep the default replay/expiry protection.
+    // Non-32-byte nonces skip this check but never verify: they are rejected
+    // by serializeNep413Message below.
     if (
       nonceValidation !== "none" &&
       maxAge !== Infinity &&

--- a/packages/near-kit/src/utils/nep413.ts
+++ b/packages/near-kit/src/utils/nep413.ts
@@ -98,6 +98,11 @@ export interface VerifyNep413Options {
    * assumes the nonce embeds a timestamp in its first 8 bytes as produced by
    * `generateNonce()`. Ignored when `nonceValidation` is `"none"`.
    *
+   * Passing `Infinity` is a legacy escape hatch that skips timestamp
+   * validation entirely, including the future-timestamp rejection — the same
+   * effect as `nonceValidation: "none"`, which is the preferred way to opt
+   * out. `NaN` falls back to the default.
+   *
    * @default 300000 (5 minutes)
    */
   maxAge?: number
@@ -112,7 +117,8 @@ export interface VerifyNep413Options {
    *
    * - `"timestamp"` (default) - Interpret the first 8 bytes of the nonce as a
    *   big-endian millisecond timestamp and reject signatures older than
-   *   `maxAge` or with future timestamps. Use this for nonces created with
+   *   `maxAge` or with future timestamps (both checks are skipped when
+   *   `maxAge` is `Infinity`). Use this for nonces created with
    *   `generateNonce()`.
    * - `"none"` - Treat the nonce as opaque bytes per the NEP-413 spec. No
    *   timestamp or expiry check is performed and `maxAge` is ignored. Use this

--- a/packages/near-kit/src/utils/nep413.ts
+++ b/packages/near-kit/src/utils/nep413.ts
@@ -93,9 +93,35 @@ export function serializeNep413Message(params: SignMessageParams): Uint8Array {
 export interface VerifyNep413Options {
   /**
    * Maximum age in milliseconds for the signature to be considered valid.
+   *
+   * Only applies when `nonceValidation` is `"timestamp"` (the default), which
+   * assumes the nonce embeds a timestamp in its first 8 bytes as produced by
+   * `generateNonce()`. Ignored when `nonceValidation` is `"none"`.
+   *
    * @default 300000 (5 minutes)
    */
   maxAge?: number
+
+  /**
+   * How to validate the nonce.
+   *
+   * NEP-413 defines the nonce as an arbitrary 32-byte value with no inherent
+   * structure. Embedding a timestamp in the first 8 bytes is a near-kit
+   * convention (used by `generateNonce()`) for automatic expiration checking,
+   * not part of the spec.
+   *
+   * - `"timestamp"` (default) - Interpret the first 8 bytes of the nonce as a
+   *   big-endian millisecond timestamp and reject signatures older than
+   *   `maxAge` or with future timestamps. Use this for nonces created with
+   *   `generateNonce()`.
+   * - `"none"` - Treat the nonce as opaque bytes per the NEP-413 spec. No
+   *   timestamp or expiry check is performed and `maxAge` is ignored. Use this
+   *   for messages signed with a custom nonce scheme. You are then responsible
+   *   for validating the nonce and preventing replay attacks yourself.
+   *
+   * @default "timestamp"
+   */
+  nonceValidation?: "timestamp" | "none"
 
   /**
    * Near client instance for verifying that the public key belongs to the account ID
@@ -121,7 +147,11 @@ export interface VerifyNep413Options {
 /**
  * Verify a NEP-413 signed message
  *
- * Automatically checks timestamp expiration (default: 5 minutes).
+ * By default, assumes the nonce follows the near-kit convention used by
+ * `generateNonce()` (first 8 bytes are a big-endian ms timestamp) and checks
+ * timestamp expiration (default: 5 minutes). NEP-413 itself treats the nonce
+ * as arbitrary 32 bytes, so for messages signed with a custom nonce scheme
+ * pass `nonceValidation: "none"` and validate the nonce yourself.
  * You must still track used nonces to prevent replay attacks.
  *
  * When `options.near` is provided, this function also verifies that the public key
@@ -146,6 +176,11 @@ export interface VerifyNep413Options {
  * // With blockchain verification to ensure key belongs to account
  * const near = new Near({ network: "mainnet" })
  * const isValid = await verifyNep413Signature(signedMessage, params, { near })
+ *
+ * // Custom nonce scheme (e.g. app-defined structure) - skip the timestamp check
+ * const isValid = await verifyNep413Signature(signedMessage, params, {
+ *   nonceValidation: "none", // caller is responsible for nonce/replay checks
+ * })
  * ```
  */
 export async function verifyNep413Signature(
@@ -154,10 +189,19 @@ export async function verifyNep413Signature(
   options: VerifyNep413Options = {},
 ): Promise<boolean> {
   try {
-    const { maxAge = 5 * 60 * 1000, near } = options // Default: 5 minutes
+    const {
+      maxAge = 5 * 60 * 1000,
+      nonceValidation = "timestamp",
+      near,
+    } = options // Default: 5 minutes
 
-    // Check timestamp expiration if maxAge is finite
-    if (maxAge !== Infinity && params.nonce.length === 32) {
+    // Check timestamp expiration if the nonce follows the near-kit timestamp
+    // convention and maxAge is finite
+    if (
+      nonceValidation === "timestamp" &&
+      maxAge !== Infinity &&
+      params.nonce.length === 32
+    ) {
       // Extract timestamp from first 8 bytes (big-endian uint64)
       const view = new DataView(
         params.nonce.buffer,
@@ -242,9 +286,12 @@ function decodeSignature(signature: string): Uint8Array | null {
 /**
  * Generate a nonce for NEP-413 message signing
  *
- * Embeds a timestamp for automatic expiration checking.
+ * NEP-413 nonces are arbitrary 32-byte values; embedding a timestamp in the
+ * first 8 bytes is a near-kit convention that lets `verifyNep413Signature`
+ * check expiration automatically. Apps are free to use their own nonce scheme
+ * instead - verify those with `nonceValidation: "none"`.
  *
- * @returns 32-byte nonce (8 bytes timestamp + 24 bytes random)
+ * @returns 32-byte nonce (8 bytes big-endian ms timestamp + 24 bytes random)
  *
  * @example
  * ```typescript

--- a/packages/near-kit/src/utils/nep413.ts
+++ b/packages/near-kit/src/utils/nep413.ts
@@ -190,10 +190,14 @@ export async function verifyNep413Signature(
 ): Promise<boolean> {
   try {
     const {
-      maxAge = 5 * 60 * 1000,
+      maxAge: rawMaxAge = 5 * 60 * 1000,
       nonceValidation = "timestamp",
       near,
     } = options // Default: 5 minutes
+
+    // NaN would make the age comparison below always false and silently
+    // disable the expiry check; fail closed by falling back to the default
+    const maxAge = Number.isNaN(rawMaxAge) ? 5 * 60 * 1000 : rawMaxAge
 
     // Check timestamp expiration if the nonce follows the near-kit timestamp
     // convention and maxAge is finite. Fail closed: only an explicit "none"

--- a/packages/near-kit/tests/unit/nep413.test.ts
+++ b/packages/near-kit/tests/unit/nep413.test.ts
@@ -395,9 +395,11 @@ describe("NEP-413 Message Signing", () => {
 })
 
 describe("NEP-413 Nonce Validation", () => {
-  // A custom nonce that does NOT follow the near-kit timestamp convention:
-  // the first 8 bytes decode to a garbage/ancient timestamp
+  // A custom nonce that does NOT follow the near-kit timestamp convention.
+  // Deterministic bytes whose first 8 bytes decode to 1 (ms since epoch,
+  // i.e. 1970), so the default timestamp validation rejects it as expired.
   const customNonce = new Uint8Array(32).fill(7)
+  customNonce.set([0, 0, 0, 0, 0, 0, 0, 1])
 
   test("should reject custom (non-timestamp) nonce with default validation", async () => {
     const keyPair = Ed25519KeyPair.fromRandom()

--- a/packages/near-kit/tests/unit/nep413.test.ts
+++ b/packages/near-kit/tests/unit/nep413.test.ts
@@ -419,6 +419,35 @@ describe("NEP-413 Nonce Validation", () => {
     expect(isValid).toBe(false)
   })
 
+  test("should reject non-32-byte nonces in any mode", async () => {
+    const keyPair = Ed25519KeyPair.fromRandom()
+    const accountId = "test.near"
+
+    const params: SignMessageParams = {
+      message: "Login to MyApp",
+      recipient: "myapp.near",
+      nonce: customNonce,
+    }
+
+    const signedMessage = keyPair.signNep413Message(accountId, params)
+
+    // A short nonce skips the timestamp check but is rejected during
+    // serialization, so verification still fails in both modes
+    const shortNonceParams: SignMessageParams = {
+      ...params,
+      nonce: new Uint8Array(16),
+    }
+
+    expect(await verifyNep413Signature(signedMessage, shortNonceParams)).toBe(
+      false,
+    )
+    expect(
+      await verifyNep413Signature(signedMessage, shortNonceParams, {
+        nonceValidation: "none",
+      }),
+    ).toBe(false)
+  })
+
   test("should not disable expiry check when maxAge is NaN", async () => {
     const keyPair = Ed25519KeyPair.fromRandom()
     const accountId = "test.near"

--- a/packages/near-kit/tests/unit/nep413.test.ts
+++ b/packages/near-kit/tests/unit/nep413.test.ts
@@ -471,6 +471,18 @@ describe("NEP-413 Nonce Validation", () => {
       maxAge: Number.NaN,
     })
     expect(isValid).toBe(false)
+
+    // Same for non-number values from untyped callers, which would
+    // otherwise coerce to NaN in the age comparison
+    const isValidWithString = await verifyNep413Signature(
+      signedMessage,
+      params,
+      {
+        // @ts-expect-error - deliberately passing an invalid value
+        maxAge: "not a number",
+      },
+    )
+    expect(isValidWithString).toBe(false)
   })
 
   test("should keep timestamp validation for unexpected nonceValidation values", async () => {

--- a/packages/near-kit/tests/unit/nep413.test.ts
+++ b/packages/near-kit/tests/unit/nep413.test.ts
@@ -394,6 +394,144 @@ describe("NEP-413 Message Signing", () => {
   })
 })
 
+describe("NEP-413 Nonce Validation", () => {
+  // A custom nonce that does NOT follow the near-kit timestamp convention:
+  // the first 8 bytes decode to a garbage/ancient timestamp
+  const customNonce = new Uint8Array(32).fill(7)
+
+  test("should reject custom (non-timestamp) nonce with default validation", async () => {
+    const keyPair = Ed25519KeyPair.fromRandom()
+    const accountId = "test.near"
+
+    const params: SignMessageParams = {
+      message: "Login to MyApp",
+      recipient: "myapp.near",
+      nonce: customNonce,
+    }
+
+    const signedMessage = keyPair.signNep413Message(accountId, params)
+
+    // Default validation interprets the first 8 bytes as a timestamp,
+    // which is ancient here, so the signature is rejected
+    const isValid = await verifyNep413Signature(signedMessage, params)
+    expect(isValid).toBe(false)
+  })
+
+  test("should verify custom nonce with nonceValidation: none", async () => {
+    const keyPair = Ed25519KeyPair.fromRandom()
+    const accountId = "test.near"
+
+    const params: SignMessageParams = {
+      message: "Login to MyApp",
+      recipient: "myapp.near",
+      nonce: customNonce,
+    }
+
+    const signedMessage = keyPair.signNep413Message(accountId, params)
+
+    // With nonceValidation: "none" the nonce is treated as opaque bytes
+    const isValid = await verifyNep413Signature(signedMessage, params, {
+      nonceValidation: "none",
+    })
+    expect(isValid).toBe(true)
+  })
+
+  test("should ignore maxAge when nonceValidation is none", async () => {
+    const keyPair = Ed25519KeyPair.fromRandom()
+    const accountId = "test.near"
+
+    // Nonce with an expired timestamp (1 hour old)
+    const expiredNonce = new Uint8Array(32)
+    const view = new DataView(expiredNonce.buffer)
+    view.setBigUint64(0, BigInt(Date.now() - 60 * 60 * 1000), false)
+
+    const params: SignMessageParams = {
+      message: "Login to MyApp",
+      recipient: "myapp.near",
+      nonce: expiredNonce,
+    }
+
+    const signedMessage = keyPair.signNep413Message(accountId, params)
+
+    // Rejected by the default timestamp validation (older than maxAge)
+    expect(await verifyNep413Signature(signedMessage, params)).toBe(false)
+
+    // Accepted when the timestamp check is skipped, even with a tiny maxAge
+    const isValid = await verifyNep413Signature(signedMessage, params, {
+      nonceValidation: "none",
+      maxAge: 1,
+    })
+    expect(isValid).toBe(true)
+  })
+
+  test("should still reject invalid signatures with nonceValidation: none", async () => {
+    const keyPair = Ed25519KeyPair.fromRandom()
+    const accountId = "test.near"
+
+    const params: SignMessageParams = {
+      message: "Login to MyApp",
+      recipient: "myapp.near",
+      nonce: customNonce,
+    }
+
+    const signedMessage = keyPair.signNep413Message(accountId, params)
+
+    // Verify against different params: the signature check must still fail
+    const differentParams: SignMessageParams = {
+      message: "Different message",
+      recipient: "myapp.near",
+      nonce: customNonce,
+    }
+
+    const isValid = await verifyNep413Signature(
+      signedMessage,
+      differentParams,
+      { nonceValidation: "none" },
+    )
+    expect(isValid).toBe(false)
+  })
+
+  test("should verify timestamp nonce with explicit nonceValidation: timestamp", async () => {
+    const keyPair = Ed25519KeyPair.fromRandom()
+    const accountId = "test.near"
+    const nonce = generateNonce()
+
+    const params: SignMessageParams = {
+      message: "Login to MyApp",
+      recipient: "myapp.near",
+      nonce,
+    }
+
+    const signedMessage = keyPair.signNep413Message(accountId, params)
+
+    const isValid = await verifyNep413Signature(signedMessage, params, {
+      nonceValidation: "timestamp",
+    })
+    expect(isValid).toBe(true)
+  })
+
+  test("should reject future timestamps with default validation", async () => {
+    const keyPair = Ed25519KeyPair.fromRandom()
+    const accountId = "test.near"
+
+    // Nonce with a timestamp 1 hour in the future (clock skew or tampering)
+    const futureNonce = new Uint8Array(32)
+    const view = new DataView(futureNonce.buffer)
+    view.setBigUint64(0, BigInt(Date.now() + 60 * 60 * 1000), false)
+
+    const params: SignMessageParams = {
+      message: "Login to MyApp",
+      recipient: "myapp.near",
+      nonce: futureNonce,
+    }
+
+    const signedMessage = keyPair.signNep413Message(accountId, params)
+
+    const isValid = await verifyNep413Signature(signedMessage, params)
+    expect(isValid).toBe(false)
+  })
+})
+
 describe("NEP-413 Near Client Validation", () => {
   test("should return false when key does not belong to account", async () => {
     const keyPair = Ed25519KeyPair.fromRandom()

--- a/packages/near-kit/tests/unit/nep413.test.ts
+++ b/packages/near-kit/tests/unit/nep413.test.ts
@@ -417,6 +417,27 @@ describe("NEP-413 Nonce Validation", () => {
     expect(isValid).toBe(false)
   })
 
+  test("should keep timestamp validation for unexpected nonceValidation values", async () => {
+    const keyPair = Ed25519KeyPair.fromRandom()
+    const accountId = "test.near"
+
+    const params: SignMessageParams = {
+      message: "Login to MyApp",
+      recipient: "myapp.near",
+      nonce: customNonce,
+    }
+
+    const signedMessage = keyPair.signNep413Message(accountId, params)
+
+    // Fail closed: an invalid option value (possible from plain JS callers)
+    // must not silently disable the timestamp/expiry protection
+    const isValid = await verifyNep413Signature(signedMessage, params, {
+      // @ts-expect-error - deliberately passing an invalid value
+      nonceValidation: "off",
+    })
+    expect(isValid).toBe(false)
+  })
+
   test("should verify custom nonce with nonceValidation: none", async () => {
     const keyPair = Ed25519KeyPair.fromRandom()
     const accountId = "test.near"

--- a/packages/near-kit/tests/unit/nep413.test.ts
+++ b/packages/near-kit/tests/unit/nep413.test.ts
@@ -419,6 +419,31 @@ describe("NEP-413 Nonce Validation", () => {
     expect(isValid).toBe(false)
   })
 
+  test("should not disable expiry check when maxAge is NaN", async () => {
+    const keyPair = Ed25519KeyPair.fromRandom()
+    const accountId = "test.near"
+
+    // Nonce with an expired timestamp (1 hour old)
+    const expiredNonce = new Uint8Array(32)
+    const view = new DataView(expiredNonce.buffer)
+    view.setBigUint64(0, BigInt(Date.now() - 60 * 60 * 1000), false)
+
+    const params: SignMessageParams = {
+      message: "Login to MyApp",
+      recipient: "myapp.near",
+      nonce: expiredNonce,
+    }
+
+    const signedMessage = keyPair.signNep413Message(accountId, params)
+
+    // NaN comparisons are always false; the default maxAge must apply
+    // instead of silently accepting the expired signature
+    const isValid = await verifyNep413Signature(signedMessage, params, {
+      maxAge: Number.NaN,
+    })
+    expect(isValid).toBe(false)
+  })
+
   test("should keep timestamp validation for unexpected nonceValidation values", async () => {
     const keyPair = Ed25519KeyPair.fromRandom()
     const accountId = "test.near"


### PR DESCRIPTION
## Summary

[NEP-413](https://github.com/near/NEPs/blob/master/neps/nep-0413.md) defines the nonce as an opaque 32-byte value — the spec attaches no semantics to it. The timestamp embedded in the first 8 bytes is a near-kit convention used by `generateNonce()` for convenient expiration checking. However, `verifyNep413Signature` unconditionally interpreted the first 8 bytes as a timestamp and enforced `maxAge`, silently rejecting valid signatures from apps that use their own nonce schemes — e.g. near.com / `intents.near` use a [versioned, salted, expirable nonce](https://github.com/near/intents/blob/6cfce73f169370ffda6409d6d32522e254d264a0/contracts/defuse/core/src/nonce/versioned.rs#L17-L19).

- Add `nonceValidation?: "timestamp" | "none"` to `VerifyNep413Options`:
  - `"timestamp"` (default) — existing behavior: first 8 bytes read as big-endian ms timestamp, `maxAge` enforced, future timestamps rejected
  - `"none"` — nonce treated as opaque bytes per the spec; no timestamp/expiry check, `maxAge` ignored; caller is responsible for nonce validation and replay protection
- Clarify JSDoc on `verifyNep413Signature`, `maxAge`, and `generateNonce` that the timestamp layout is a near-kit convention, not part of NEP-413
- Docs: clarify the convention in `message-signing.mdx` and add a "Custom Nonce Schemes" section
- Changeset (minor)

Backward compatible — the default behavior is unchanged.

## Test plan

- [x] New unit tests: custom nonce verifies with `nonceValidation: "none"` but fails with the default; expired/future timestamp nonces still rejected by default; `maxAge` ignored with `"none"`; invalid signatures still rejected with `"none"`
- [x] `bun run lint`, `bun run build`, `bun run typecheck`, `bun run --filter near-kit test:unit` (1047 tests) pass locally