### PR TITLE
feat(rpc): add view_gas_key_nonces reader

### DIFF
--- a/.changeset/view-gas-key-nonces.md
+++ b/.changeset/view-gas-key-nonces.md
@@ -1,0 +1,8 @@
+---
+"near-kit": minor
+---
+
+Add `RpcClient.getGasKeyNonces` to read a gas key's per-lane nonces via the `view_gas_key_nonces` query (NEAR 2.13)
+
+- Returns a typed `GasKeyNoncesResponse` (`{ nonces, block_height, block_hash }`), mirroring `getAccessKey`; `nonces` is the gas key's parallel per-lane `u64` nonces indexed by lane.
+- Maps the node's `UNKNOWN_GAS_KEY` error to `AccessKeyDoesNotExistError`, re-keyed with the queried account, so reading a non-gas key throws the same typed error as the access-key path.

--- a/packages/near-kit/src/core/rpc/rpc-error-handler.ts
+++ b/packages/near-kit/src/core/rpc/rpc-error-handler.ts
@@ -337,6 +337,18 @@ export function parseRpcError(
       throw new AccountDoesNotExistError(accountId)
     }
 
+    // A `view_gas_key_nonces` query for a key that is not a (funded) gas key.
+    // nearcore only echoes the public key here, not the account, so callers
+    // that know the account re-key this with full context (see getGasKeyNonces).
+    if (causeName === "UNKNOWN_GAS_KEY") {
+      const publicKey = (causeInfo["public_key"] as string) || "unknown"
+      const accountId =
+        (causeInfo["account_id"] as string) ||
+        (causeInfo.requested_account_id as string) ||
+        "unknown"
+      throw new AccessKeyDoesNotExistError(accountId, publicKey)
+    }
+
     if (causeName === "UNAVAILABLE_SHARD") {
       throw new ShardUnavailableError(parsedError.message)
     }

--- a/packages/near-kit/src/core/rpc/rpc-schemas.ts
+++ b/packages/near-kit/src/core/rpc/rpc-schemas.ts
@@ -235,6 +235,21 @@ export const AccessKeyListResponseSchema = z.object({
 })
 
 /**
+ * Gas-key nonces response schema (nearcore 2.13).
+ *
+ * Response of a `view_gas_key_nonces` query: `nonces` is the gas key's parallel
+ * per-lane nonces (one `u64` per nonce slot, indexed by lane), alongside the
+ * usual `block_height` / `block_hash` the query was answered against. Nonces are
+ * typed as `z.number()` to match how `AccessKeyViewSchema` types the `u64` key
+ * nonce.
+ */
+export const GasKeyNoncesResponseSchema = z.object({
+  nonces: z.array(z.number()),
+  block_height: z.number(),
+  block_hash: z.string(),
+})
+
+/**
  * Receipt-to-transaction response schema (for EXPERIMENTAL_receipt_to_tx)
  *
  * Maps a receipt ID back to its originating transaction. Both fields are
@@ -795,6 +810,7 @@ export type BlockView = z.infer<typeof BlockViewSchema>
 export type StatusResponse = z.infer<typeof StatusResponseSchema>
 export type GasPriceResponse = z.infer<typeof GasPriceResponseSchema>
 export type AccessKeyListResponse = z.infer<typeof AccessKeyListResponseSchema>
+export type GasKeyNoncesResponse = z.infer<typeof GasKeyNoncesResponseSchema>
 export type ReceiptToTxResponse = z.infer<typeof ReceiptToTxResponseSchema>
 export type StateItem = z.infer<typeof StateItemSchema>
 export type ViewStateResult = z.infer<typeof ViewStateResultSchema>

--- a/packages/near-kit/src/core/rpc/rpc.ts
+++ b/packages/near-kit/src/core/rpc/rpc.ts
@@ -1,5 +1,6 @@
 import { base64 } from "@scure/base"
 import {
+  AccessKeyDoesNotExistError,
   InvalidTransactionError,
   NearError,
   NetworkError,
@@ -16,6 +17,7 @@ import type {
   FinalExecutionOutcomeMap,
   FinalExecutionOutcomeWithReceipts,
   FinalExecutionOutcomeWithReceiptsMap,
+  GasKeyNoncesResponse,
   GasPriceResponse,
   GenesisConfigResponse,
   MaintenanceWindowsResponse,
@@ -40,6 +42,7 @@ import {
   BlockViewSchema,
   FinalExecutionOutcomeSchema,
   FinalExecutionOutcomeWithReceiptsSchema,
+  GasKeyNoncesResponseSchema,
   GasPriceResponseSchema,
   GenesisConfigResponseSchema,
   MaintenanceWindowsResponseSchema,
@@ -349,6 +352,46 @@ export class RpcClient {
     })
 
     return AccessKeyListResponseSchema.parse(result)
+  }
+
+  /**
+   * Get a gas key's per-lane nonces via `view_gas_key_nonces` (nearcore 2.13).
+   *
+   * A gas key funds several parallel nonce lanes (`num_nonces` slots) so it can
+   * sign multiple transactions concurrently; this returns the current `u64`
+   * nonce of each lane, indexed by lane, plus the block the query was answered
+   * against. Throws {@link AccessKeyDoesNotExistError} if `publicKey` is not a
+   * gas key on `accountId`.
+   *
+   * @param accountId - Account ID that owns the gas key.
+   * @param publicKey - Gas key public key string (e.g. `"ed25519:..."`).
+   * @param options - Optional {@link BlockReference} to control finality or block.
+   */
+  async getGasKeyNonces(
+    accountId: string,
+    publicKey: string,
+    options?: BlockReference,
+  ): Promise<GasKeyNoncesResponse> {
+    // Unlike view_access_key (whose "does not exist" arrives in `result.error`),
+    // view_gas_key_nonces reports a missing gas key as a typed UNKNOWN_GAS_KEY
+    // JSON-RPC error. parseRpcError already maps that to AccessKeyDoesNotExistError
+    // but nearcore only echoes the public key, so we re-key it with the queried
+    // account for a complete error.
+    const result = await this.call("query", {
+      request_type: "view_gas_key_nonces",
+      ...(options?.blockId
+        ? { block_id: options.blockId }
+        : { finality: options?.finality || "optimistic" }),
+      account_id: accountId,
+      public_key: publicKey,
+    }).catch((error) => {
+      if (error instanceof AccessKeyDoesNotExistError) {
+        throw new AccessKeyDoesNotExistError(accountId, publicKey)
+      }
+      throw error
+    })
+
+    return GasKeyNoncesResponseSchema.parse(result)
   }
 
   /**

--- a/packages/near-kit/src/core/types.ts
+++ b/packages/near-kit/src/core/types.ts
@@ -263,6 +263,7 @@ import type { FinalExecutionOutcome } from "./rpc/rpc-schemas.js"
  * - StatusResponse: Network status information
  * - GasPriceResponse: Gas price information
  * - AccessKeyListResponse: Access key list from view_access_key_list query
+ * - GasKeyNoncesResponse: Gas key per-lane nonces from view_gas_key_nonces query
  * - ReceiptToTxResponse: Originating transaction info from EXPERIMENTAL_receipt_to_tx
  * - RpcErrorResponse: RPC error response structure
  */
@@ -275,6 +276,7 @@ export type {
   BlockHeaderView,
   BlockView,
   ChunkHeaderView,
+  GasKeyNoncesResponse,
   GasPriceResponse,
   GenesisConfigResponse,
   MaintenanceWindow,

--- a/packages/near-kit/src/index.ts
+++ b/packages/near-kit/src/index.ts
@@ -34,6 +34,7 @@ export type {
   AccountState,
   CallOptions,
   FinalExecutionOutcome,
+  GasKeyNoncesResponse,
   KeyConfig,
   KeyPair,
   KeyStore,

--- a/packages/near-kit/tests/integration/gas-key-nonces.test.ts
+++ b/packages/near-kit/tests/integration/gas-key-nonces.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Integration test for the `view_gas_key_nonces` reader (NEAR 2.13).
+ *
+ * End-to-end: create an account, add a gas full-access key with N parallel
+ * nonce lanes, fund it, then read the lanes back with
+ * `RpcClient.getGasKeyNonces` and assert we get exactly N sane per-lane nonces
+ * plus the block context. Also asserts that reading a non-gas key rejects.
+ *
+ * Sandbox version overridable via NEAR_SANDBOX_VERSION; defaults to a 2.13 RC.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+import { Near } from "../../src/core/near.js"
+import { AccessKeyDoesNotExistError } from "../../src/errors/index.js"
+import { Sandbox } from "../../src/sandbox/sandbox.js"
+import { generateKey } from "../../src/utils/key.js"
+
+const SANDBOX_VERSION = process.env.NEAR_SANDBOX_VERSION ?? "2.13.0-rc.2"
+
+describe("view_gas_key_nonces reader - Integration Test (NEAR 2.13)", () => {
+  let sandbox: Sandbox
+  let near: Near
+
+  beforeAll(async () => {
+    sandbox = await Sandbox.start({ version: SANDBOX_VERSION })
+    near = new Near({
+      network: sandbox,
+      keyStore: {
+        [sandbox.rootAccount.id]: sandbox.rootAccount.secretKey,
+      },
+    })
+    console.log(
+      `✓ Sandbox ${SANDBOX_VERSION} started: ${sandbox.rootAccount.id}`,
+    )
+  }, 180000)
+
+  afterAll(async () => {
+    if (sandbox) {
+      await sandbox.stop()
+    }
+  })
+
+  test("reads N per-lane nonces from a funded gas key", async () => {
+    const accountId = `gknonces-${Date.now()}.${sandbox.rootAccount.id}`
+    const accountKey = generateKey()
+    const gasKey = generateKey()
+    const NUM_NONCES = 3
+
+    // Create the gas-key owner with a normal full-access key.
+    await near
+      .transaction(sandbox.rootAccount.id)
+      .createAccount(accountId)
+      .transfer(accountId, "10 NEAR")
+      .addKey(accountKey.publicKey.toString(), { type: "fullAccess" })
+      .send()
+
+    const ownerNear = new Near({
+      network: sandbox,
+      keyStore: { [accountId]: accountKey.secretKey },
+    })
+
+    // Add a gas full-access key with NUM_NONCES parallel lanes and fund it.
+    await ownerNear
+      .transaction(accountId)
+      .addKey(gasKey.publicKey.toString(), {
+        type: "gasKeyFullAccess",
+        numNonces: NUM_NONCES,
+      })
+      .transferToGasKey(gasKey.publicKey.toString(), "5 NEAR")
+      .send()
+
+    // Read the lanes back through the new typed reader.
+    const response = await near.rpc.getGasKeyNonces(
+      accountId,
+      gasKey.publicKey.toString(),
+    )
+
+    expect(response.nonces).toHaveLength(NUM_NONCES)
+    for (const nonce of response.nonces) {
+      expect(Number.isInteger(nonce)).toBe(true)
+      expect(nonce).toBeGreaterThanOrEqual(0)
+    }
+    expect(response.block_height).toBeGreaterThan(0)
+    expect(typeof response.block_hash).toBe("string")
+    expect(response.block_hash.length).toBeGreaterThan(0)
+    console.log(
+      `✓ Read ${response.nonces.length} gas-key nonce lanes: [${response.nonces.join(", ")}]`,
+    )
+  }, 60000)
+
+  test("rejects when the public key is not a gas key", async () => {
+    const accountId = `gknorm-${Date.now()}.${sandbox.rootAccount.id}`
+    const accountKey = generateKey()
+
+    // A plain account whose full-access key is NOT a gas key.
+    await near
+      .transaction(sandbox.rootAccount.id)
+      .createAccount(accountId)
+      .transfer(accountId, "1 NEAR")
+      .addKey(accountKey.publicKey.toString(), { type: "fullAccess" })
+      .send()
+
+    await expect(
+      near.rpc.getGasKeyNonces(accountId, accountKey.publicKey.toString()),
+    ).rejects.toBeInstanceOf(AccessKeyDoesNotExistError)
+  }, 60000)
+})

--- a/packages/near-kit/tests/unit/gas-key-views.test.ts
+++ b/packages/near-kit/tests/unit/gas-key-views.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, test } from "vitest"
 import {
   AccessKeyPermissionSchema,
+  GasKeyNoncesResponseSchema,
   ActionSchema as RpcActionSchema,
 } from "../../src/core/rpc/rpc-schemas.js"
 
@@ -77,5 +78,33 @@ describe("RpcActionSchema (gas-key actions)", () => {
   test("still parses a classic action (Transfer)", () => {
     const parsed = RpcActionSchema.parse({ Transfer: { deposit: "1" } })
     expect(parsed).toEqual({ Transfer: { deposit: "1" } })
+  })
+})
+
+describe("GasKeyNoncesResponseSchema", () => {
+  test("parses a multi-lane gas-key nonces response", () => {
+    const parsed = GasKeyNoncesResponseSchema.parse({
+      nonces: [12, 0, 5, 0],
+      block_height: 42,
+      block_hash: "11111111111111111111111111111111",
+    })
+    expect(parsed.nonces).toEqual([12, 0, 5, 0])
+    expect(parsed.block_height).toBe(42)
+    expect(parsed.block_hash).toBe("11111111111111111111111111111111")
+  })
+
+  test("parses a freshly funded gas key (all lanes at zero)", () => {
+    const parsed = GasKeyNoncesResponseSchema.parse({
+      nonces: [0, 0],
+      block_height: 1,
+      block_hash: "abc",
+    })
+    expect(parsed.nonces).toEqual([0, 0])
+  })
+
+  test("rejects a response missing the nonces array", () => {
+    expect(() =>
+      GasKeyNoncesResponseSchema.parse({ block_height: 1, block_hash: "abc" }),
+    ).toThrow()
   })
 })

--- a/packages/near-kit/tests/unit/rpc-error-handler-unit.test.ts
+++ b/packages/near-kit/tests/unit/rpc-error-handler-unit.test.ts
@@ -363,6 +363,36 @@ describe("parseRpcError", () => {
       }
     })
 
+    test("should throw AccessKeyDoesNotExistError for UNKNOWN_GAS_KEY", () => {
+      // Captured from a 2.13 sandbox: view_gas_key_nonces on a non-gas key.
+      const error = {
+        name: "HANDLER_ERROR",
+        code: -32000,
+        message: "Server error",
+        data: "Gas key for public key ed25519:DQbqznEcti9RZZtjociwmoLUHDu2sAewsfowWBmXv3s5 does not exist while viewing",
+        cause: {
+          name: "UNKNOWN_GAS_KEY",
+          info: {
+            block_hash: "GoWEodM1by6QoEJfV9NMacT8qidM8haHGP8eCL4dZ4kv",
+            block_height: 3,
+            public_key: "ed25519:DQbqznEcti9RZZtjociwmoLUHDu2sAewsfowWBmXv3s5",
+          },
+        },
+      }
+
+      expect(() => parseRpcError(error)).toThrow(AccessKeyDoesNotExistError)
+
+      try {
+        parseRpcError(error)
+      } catch (e) {
+        expect(e).toBeInstanceOf(AccessKeyDoesNotExistError)
+        const err = e as AccessKeyDoesNotExistError
+        expect(err.publicKey).toBe(
+          "ed25519:DQbqznEcti9RZZtjociwmoLUHDu2sAewsfowWBmXv3s5",
+        )
+      }
+    })
+
     test("should throw ShardUnavailableError for UNAVAILABLE_SHARD", () => {
       const error = {
         name: "HANDLER_ERROR",


### PR DESCRIPTION
## What & why

Adds the one remaining gas-key RPC reader that `RpcClient` was missing. Gas keys and DelegateV2 already shipped end-to-end (PRs #196, #197, #199, #202), but there was no typed way to read a gas key's per-lane nonces — the client had `getAccessKey` (`view_access_key`) and `getAccessKeys` (`view_access_key_list`) but nothing for `view_gas_key_nonces`. This fills that gap.

## Changes

- **`RpcClient.getGasKeyNonces(accountId, publicKey, options?)`** (`packages/near-kit/src/core/rpc/rpc.ts`) queries `view_gas_key_nonces` following the exact block-reference / finality pattern of `getAccessKey`, and returns a typed `GasKeyNoncesResponse`.
- **`GasKeyNoncesResponseSchema`** (`rpc-schemas.ts`): `{ nonces: number[], block_height, block_hash }`. A gas key funds several parallel nonce lanes (`num_nonces` slots); `nonces` is the current `u64` nonce of each lane, indexed by lane. `nonces` is typed as `z.number()` to match how `AccessKeyViewSchema` types the `u64` key nonce.
- **Error handling**: empirically, a missing/not-a-gas-key comes back as a *typed* `UNKNOWN_GAS_KEY` JSON-RPC error (not embedded in `result.error` the way `view_access_key`'s "does not exist" is). `parseRpcError` now maps `UNKNOWN_GAS_KEY` → `AccessKeyDoesNotExistError` (consistent with `UNKNOWN_ACCOUNT` → `AccountDoesNotExistError`); since nearcore only echoes the public key there, `getGasKeyNonces` re-keys it with the queried account for a complete error.
- **Exports**: `GasKeyNoncesResponse` is re-exported through `core/types.ts` and `src/index.ts` in the existing style.

## How it was tested

- **Unit**: schema parsing (`tests/unit/gas-key-views.test.ts`) and the `UNKNOWN_GAS_KEY` → `AccessKeyDoesNotExistError` mapping using a fixture captured from a real 2.13 sandbox (`tests/unit/rpc-error-handler-unit.test.ts`).
- **Integration** (`tests/integration/gas-key-nonces.test.ts`, against a 2.13.0-rc.2 sandbox): create + fund a gas full-access key with N nonce lanes, read them back with `getGasKeyNonces`, assert exactly N sane per-lane nonces plus block context; and assert reading a non-gas key rejects with `AccessKeyDoesNotExistError`.
- The response shape was confirmed empirically against the sandbox and cross-checked against nearcore (`GasKeyNoncesView` + query `block_height`/`block_hash`).

`bun run build`, `typecheck`, `lint`, and the unit + new integration tests all pass locally. Changeset included (`near-kit`: minor).