### PR TITLE
build(sandbox): default to nearcore 2.13.0 stable

### DIFF
--- a/.changeset/sandbox-nearcore-2-13-0.md
+++ b/.changeset/sandbox-nearcore-2-13-0.md
@@ -1,0 +1,5 @@
+---
+"near-kit": patch
+---
+
+Default the sandbox to nearcore 2.13.0 (stable mainnet release) instead of the 2.13.0-rc.2 release candidate.

--- a/packages/near-kit/src/sandbox/sandbox.ts
+++ b/packages/near-kit/src/sandbox/sandbox.ts
@@ -23,7 +23,7 @@ import { pipeline } from "node:stream/promises"
 import type { ReadableStream as WebReadableStream } from "node:stream/web"
 import * as tar from "tar"
 
-const DEFAULT_VERSION = "2.13.0-rc.2"
+const DEFAULT_VERSION = "2.13.0"
 const BINARY_NAME = "near-sandbox"
 const ARCHIVE_NAME = "near-sandbox.tar.gz"
 const DOWNLOAD_BASE =


### PR DESCRIPTION
## What & why

nearcore **2.13.0** is now the stable mainnet release, so the default sandbox binary should move off the `2.13.0-rc.2` release candidate.

One-line change: `DEFAULT_VERSION` in `packages/near-kit/src/sandbox/sandbox.ts` goes from `"2.13.0-rc.2"` → `"2.13.0"`.

This also stops the daily **Check Nearcore Release** cron from flagging drift — that workflow greps `DEFAULT_VERSION` and compares it against `gh api repos/near/nearcore/releases/latest` (now `2.13.0`).

## Scope

Only the default is bumped. The gas-key / DelegateV2 / ML-DSA / view-state integration tests intentionally pin `2.13.0-rc.2` via `NEAR_SANDBOX_VERSION ?? "2.13.0-rc.2"` (their comments note they pin a known image independent of the default bump), so they are deliberately left untouched. The cron only tracks `DEFAULT_VERSION`, so this fully addresses the drift.

## How it was tested

- `bun run build`, `typecheck`, `lint` pass.
- Verified the 2.13.0 stable binary downloads and runs: `tests/integration/sandbox.test.ts` (which starts a sandbox via `Sandbox.start()`, i.e. `DEFAULT_VERSION`) passes 27/27 against 2.13.0.

Changeset included (`near-kit`: patch).