### PR TITLE
fix(sandbox): map Linux arm64 to aarch64 for binary downloads

### DIFF
--- a/.changeset/fix-linux-arm64-sandbox-download.md
+++ b/.changeset/fix-linux-arm64-sandbox-download.md
@@ -1,0 +1,5 @@
+---
+"near-kit": patch
+---
+
+Fix sandbox binary download on Linux ARM: map Node's `arm64` arch to the `Linux-aarch64` S3 path (previously produced a `Linux-arm64` URL that returned 403)

--- a/packages/near-kit/src/sandbox/sandbox.ts
+++ b/packages/near-kit/src/sandbox/sandbox.ts
@@ -640,24 +640,31 @@ export class Sandbox {
 
 /**
  * Get platform identifier for downloading correct binary.
+ * Exported for testing only.
  * @internal
  */
-function getPlatformId(): PlatformInfo {
-  const system = os.platform()
-  const arch = os.arch()
-
-  const platform = system === "darwin" ? "Darwin" : "Linux"
-  const normalizedArch = arch === "x64" ? "x86_64" : arch
-
-  if (!["x86_64", "arm64"].includes(normalizedArch)) {
-    throw new Error(`Unsupported architecture: ${arch}`)
-  }
-
+export function getPlatformId(
+  system: string = os.platform(),
+  arch: string = os.arch(),
+): PlatformInfo {
   if (system !== "darwin" && system !== "linux") {
     throw new Error(`Unsupported platform: ${system}`)
   }
 
-  return { system: platform, arch: normalizedArch }
+  let normalizedArch: string
+  if (arch === "x64") {
+    normalizedArch = "x86_64"
+  } else if (arch === "arm64") {
+    // S3 publishes Linux ARM builds under "aarch64" but Darwin under "arm64"
+    normalizedArch = system === "linux" ? "aarch64" : "arm64"
+  } else {
+    throw new Error(`Unsupported architecture: ${arch}`)
+  }
+
+  return {
+    system: system === "darwin" ? "Darwin" : "Linux",
+    arch: normalizedArch,
+  }
 }
 
 /**

--- a/packages/near-kit/tests/unit/sandbox-platform-id.test.ts
+++ b/packages/near-kit/tests/unit/sandbox-platform-id.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for sandbox binary platform identification
+ *
+ * The download URL is `${DOWNLOAD_BASE}/${system}-${arch}/${version}/near-sandbox.tar.gz`,
+ * so system/arch must match the S3 paths exactly. Notably, Linux ARM builds are
+ * published under "aarch64" while Darwin ARM builds use "arm64".
+ */
+
+import { describe, expect, test } from "vitest"
+import { getPlatformId } from "../../src/sandbox/sandbox.js"
+
+describe("getPlatformId", () => {
+  test("maps linux x64 to Linux-x86_64", () => {
+    expect(getPlatformId("linux", "x64")).toEqual({
+      system: "Linux",
+      arch: "x86_64",
+    })
+  })
+
+  test("maps linux arm64 to Linux-aarch64", () => {
+    expect(getPlatformId("linux", "arm64")).toEqual({
+      system: "Linux",
+      arch: "aarch64",
+    })
+  })
+
+  test("maps darwin x64 to Darwin-x86_64", () => {
+    expect(getPlatformId("darwin", "x64")).toEqual({
+      system: "Darwin",
+      arch: "x86_64",
+    })
+  })
+
+  test("maps darwin arm64 to Darwin-arm64", () => {
+    expect(getPlatformId("darwin", "arm64")).toEqual({
+      system: "Darwin",
+      arch: "arm64",
+    })
+  })
+
+  test("throws on unsupported platform", () => {
+    expect(() => getPlatformId("win32", "x64")).toThrow(
+      "Unsupported platform: win32",
+    )
+  })
+
+  test("throws on unsupported architecture", () => {
+    expect(() => getPlatformId("linux", "ia32")).toThrow(
+      "Unsupported architecture: ia32",
+    )
+  })
+
+  test("defaults to the current process platform", () => {
+    // On any supported dev/CI machine this should resolve without throwing
+    const { system, arch } = getPlatformId()
+    expect(["Linux", "Darwin"]).toContain(system)
+    expect(["x86_64", "aarch64", "arm64"]).toContain(arch)
+  })
+})

--- a/packages/near-kit/tests/unit/sandbox-platform-id.test.ts
+++ b/packages/near-kit/tests/unit/sandbox-platform-id.test.ts
@@ -6,6 +6,7 @@
  * published under "aarch64" while Darwin ARM builds use "arm64".
  */
 
+import os from "node:os"
 import { describe, expect, test } from "vitest"
 import { getPlatformId } from "../../src/sandbox/sandbox.js"
 
@@ -50,10 +51,13 @@ describe("getPlatformId", () => {
     )
   })
 
-  test("defaults to the current process platform", () => {
-    // On any supported dev/CI machine this should resolve without throwing
-    const { system, arch } = getPlatformId()
-    expect(["Linux", "Darwin"]).toContain(system)
-    expect(["x86_64", "aarch64", "arm64"]).toContain(arch)
-  })
+  // Only meaningful on hosts the sandbox supports; would throw on e.g. Windows
+  test.runIf(["linux", "darwin"].includes(os.platform()))(
+    "defaults to the current process platform",
+    () => {
+      const { system, arch } = getPlatformId()
+      expect(["Linux", "Darwin"]).toContain(system)
+      expect(["x86_64", "aarch64", "arm64"]).toContain(arch)
+    },
+  )
 })


### PR DESCRIPTION
## Summary

- `getPlatformId()` passed Node's `os.arch()` value `arm64` straight into the S3 download URL, producing `Linux-arm64` paths that return 403 — nearcore publishes Linux ARM builds under `Linux-aarch64` (verified: the aarch64 URL returns 200)
- Map `linux` + `arm64` → `aarch64`; Darwin correctly stays `arm64`
- Parameterize `getPlatformId()` (defaults to `os.platform()`/`os.arch()`) and export it as `@internal` so the mapping is unit-testable — not re-exported from the public `/sandbox` subpath
- Add unit tests covering all four platform combos plus unsupported platform/arch errors
- Add patch changeset

## Test plan

- [x] Unit tests pass (1072 tests, including 7 new)
- [x] Lint passes; source typecheck (`tsc --noEmit -p tsconfig.json`) passes

Note: `bun run typecheck` fails identically on a clean tree in this environment (TS6310/TS6059 with TypeScript 6.0.3) — pre-existing, unrelated to this change.