### PR TITLE
fix(wallets): support global contracts and requested finality

### DIFF
--- a/.changeset/wallet-global-contracts-and-confirmation.md
+++ b/.changeset/wallet-global-contracts-and-confirmation.md
@@ -2,4 +2,4 @@
 "near-kit": patch
 ---
 
-Support publishing and using global contracts through NEAR Connect. Honor requested transaction confirmation levels for wallet-backed calls and transfers, querying the submitted transaction when further confirmation is needed.
+Support publishing and using global contracts through NEAR Connect, and recognize global references when checking whether an account has a contract. Honor requested transaction confirmation levels for wallet-backed calls and transfers, querying the submitted transaction when further confirmation is needed.

--- a/.changeset/wallet-global-contracts-and-confirmation.md
+++ b/.changeset/wallet-global-contracts-and-confirmation.md
@@ -1,0 +1,5 @@
+---
+"near-kit": patch
+---
+
+Support publishing and using global contracts through NEAR Connect. Honor requested transaction confirmation levels for wallet-backed calls and transfers, querying the submitted transaction when further confirmation is needed.

--- a/docs/dapp-workflow/frontend-integration.mdx
+++ b/docs/dapp-workflow/frontend-integration.mdx
@@ -58,6 +58,38 @@ connector.on("wallet:signIn", async (data) => {
 connector.connect()
 ```
 
+## Global Contracts and Confirmation
+
+The NEAR Connect adapter supports `deployFromPublished` and `publishContract`
+with wallets that support the corresponding global-contract actions. For
+example, attach published code and initialize it in one wallet approval:
+
+```typescript
+const wallet = await connector.wallet()
+const [{ accountId }] = await wallet.getAccounts()
+
+const result = await near
+  .transaction(accountId)
+  .deployFromPublished({ accountId: "publisher.testnet" })
+  .functionCall(accountId, "init", {}, { gas: "100 Tgas" })
+  .send({ waitUntil: "FINAL" })
+```
+
+Use an account intended for the new contract; attaching code changes that
+account's contract. References can also use `{ codeHash: "<base58 hash>" }`.
+See [Global Contracts](/in-depth/global-contracts) for publishing and reference options.
+
+Wallets control when their signing request returns. If the outcome has not
+reached the requested `waitUntil` (or configured `defaultWaitUntil`), near-kit
+queries its RPC for confirmation using the submitted transaction hash. This
+does not request another signature or resubmit the transaction. The same
+behavior applies to `near.call()` and `near.send()`.
+
+Wallet connection and optional function-call key permission requests are
+configured through NEAR Connect. A restricted function-call key cannot authorize
+global-contract deployment; the wallet must approve that action using an
+account with full-access authority.
+
 ## Best Practice: React Context
 
 <Tip>

--- a/docs/essentials/reading-data.mdx
+++ b/docs/essentials/reading-data.mdx
@@ -101,6 +101,10 @@ console.log(`Storage bytes: ${account.storageBytes}`)      // Raw storage in byt
 console.log(`Has contract: ${account.hasContract}`)        // Whether contract is deployed
 ```
 
+`hasContract` includes accounts using a global contract by publisher account or
+code hash. To inspect the reference, use `near.rpc.getAccount(accountId)` and
+read `global_contract_account_id` or `global_contract_hash`.
+
 <Note>
 **Why is available different from balance?**
 

--- a/docs/reference/data-structures.mdx
+++ b/docs/reference/data-structures.mdx
@@ -65,13 +65,15 @@ type ExecutionOutcomeWithId = {
 
 ## Account Details (`AccountView`)
 
-Returned by `near.getAccountDetails(accountId)`.
+Returned by `near.rpc.getAccount(accountId)`.
 
 ```typescript
 type AccountView = {
   amount: string; // Balance in yoctoNEAR
   locked: string; // Staked balance in yoctoNEAR
   code_hash: string; // Hash of the contract code (111111... if none)
+  global_contract_hash?: string | null; // Global contract referenced by code hash
+  global_contract_account_id?: string | null; // Global contract referenced by publisher
   storage_usage: number; // Storage used in bytes
   storage_paid_at: number;
   block_height: number;

--- a/packages/near-kit/src/core/near.ts
+++ b/packages/near-kit/src/core/near.ts
@@ -609,7 +609,10 @@ export class Near {
         includeSuffix: false,
       }),
       storageBytes: account.storage_usage,
-      hasContract: account.code_hash !== emptyCodeHash,
+      hasContract:
+        account.code_hash !== emptyCodeHash ||
+        account.global_contract_hash != null ||
+        account.global_contract_account_id != null,
       codeHash: account.code_hash,
     }
   }

--- a/packages/near-kit/src/core/near.ts
+++ b/packages/near-kit/src/core/near.ts
@@ -15,18 +15,13 @@ import { formatAmount } from "../utils/amount.js"
 import { parseKey } from "../utils/key.js"
 import { generateNonce } from "../utils/nep413.js"
 import type { Amount, Gas } from "../utils/validation.js"
-import { normalizeAmount, normalizeGas } from "../utils/validation.js"
-import * as actions from "./actions.js"
 import {
   type BlockReference,
   type NearConfig,
   NearConfigSchema,
   resolveNetworkConfig,
 } from "./config-schemas.js"
-import {
-  DEFAULT_FUNCTION_CALL_GAS,
-  STORAGE_AMOUNT_PER_BYTE,
-} from "./constants.js"
+import { STORAGE_AMOUNT_PER_BYTE } from "./constants.js"
 import { RpcClient } from "./rpc/rpc.js"
 import type {
   AccessKeyListResponse,
@@ -352,38 +347,6 @@ export class Near {
   ): Promise<T> {
     const signerId = await this.getSignerId(options.signerId)
 
-    // Use wallet if available
-    if (this.wallet) {
-      const argsBytes =
-        args instanceof Uint8Array
-          ? args
-          : new TextEncoder().encode(JSON.stringify(args))
-
-      const gas = options.gas
-        ? normalizeGas(options.gas)
-        : DEFAULT_FUNCTION_CALL_GAS
-
-      const deposit = options.attachedDeposit
-        ? normalizeAmount(options.attachedDeposit)
-        : "0"
-
-      const result = await this.wallet.signAndSendTransaction({
-        signerId,
-        receiverId: contractId,
-        actions: [
-          actions.functionCall(
-            methodName,
-            argsBytes,
-            BigInt(gas),
-            BigInt(deposit),
-          ),
-        ],
-      })
-
-      return result as T
-    }
-
-    // Use private key/signer approach
     const functionCallOptions: {
       gas?: Gas
       attachedDeposit?: Amount
@@ -428,18 +391,6 @@ export class Near {
   ): Promise<FinalExecutionOutcome> {
     const signerId = await this.getSignerId()
 
-    // Use wallet if available
-    if (this.wallet) {
-      const amountYocto = normalizeAmount(amount)
-
-      return await this.wallet.signAndSendTransaction({
-        signerId,
-        receiverId,
-        actions: [actions.transfer(BigInt(amountYocto))],
-      })
-    }
-
-    // Use private key/signer approach
     return await this.transaction(signerId).transfer(receiverId, amount).send()
   }
 

--- a/packages/near-kit/src/core/rpc/rpc-schemas.ts
+++ b/packages/near-kit/src/core/rpc/rpc-schemas.ts
@@ -79,6 +79,8 @@ export const AccountViewSchema = z.object({
   amount: z.string(),
   locked: z.string(),
   code_hash: z.string(),
+  global_contract_hash: z.string().nullable().optional(),
+  global_contract_account_id: z.string().nullable().optional(),
   storage_usage: z.number(),
   storage_paid_at: z.number(),
   block_height: z.number(),

--- a/packages/near-kit/src/core/transaction.ts
+++ b/packages/near-kit/src/core/transaction.ts
@@ -1519,20 +1519,58 @@ export class TransactionBuilder {
       )
     }
 
-    // Use wallet if available
+    const waitUntil = (options?.waitUntil ?? this.defaultWaitUntil) as W
+
     if (this.wallet) {
       const result = await this.wallet.signAndSendTransaction({
         signerId: this.signerId,
         receiverId: this.receiverId,
         actions: this.actions,
       })
-      // Wallet doesn't support waitUntil parameter, always returns executed result
-      // Cast to the expected type (this is safe because wallet always waits for execution)
-      return result as FinalExecutionOutcomeMap[W]
+      // Inclusion finality and optimistic execution are independent milestones.
+      const reached: Record<TxExecutionStatus, readonly TxExecutionStatus[]> = {
+        NONE: ["NONE"],
+        INCLUDED: ["NONE", "INCLUDED"],
+        INCLUDED_FINAL: ["NONE", "INCLUDED", "INCLUDED_FINAL"],
+        EXECUTED_OPTIMISTIC: ["NONE", "INCLUDED", "EXECUTED_OPTIMISTIC"],
+        EXECUTED: [
+          "NONE",
+          "INCLUDED",
+          "INCLUDED_FINAL",
+          "EXECUTED_OPTIMISTIC",
+          "EXECUTED",
+        ],
+        FINAL: [
+          "NONE",
+          "INCLUDED",
+          "INCLUDED_FINAL",
+          "EXECUTED_OPTIMISTIC",
+          "EXECUTED",
+          "FINAL",
+        ],
+      }
+      const failed =
+        typeof result.status === "object" && "Failure" in result.status
+      if (
+        !failed &&
+        reached[result.final_execution_status]?.includes(waitUntil)
+      ) {
+        return result as FinalExecutionOutcomeMap[W]
+      }
+      if (!result.transaction?.hash) {
+        throw new NearError(
+          "Wallet did not return a transaction hash for status lookup",
+          "INVALID_TRANSACTION",
+        )
+      }
+      // Reconcile the submitted hash; never prompt for another signature on error.
+      // RPC status parsing also provides the usual typed execution errors.
+      return (await this.rpc.getTransactionStatus(
+        result.transaction.hash,
+        result.transaction.signer_id,
+        waitUntil,
+      )) as FinalExecutionOutcomeMap[W]
     }
-
-    // Determine waitUntil - use option if provided, otherwise use default
-    const waitUntil = (options?.waitUntil ?? this.defaultWaitUntil) as W
 
     // Retry loop for InvalidNonceError
     const MAX_NONCE_RETRIES = 3

--- a/packages/near-kit/src/wallets/adapters.ts
+++ b/packages/near-kit/src/wallets/adapters.ts
@@ -13,7 +13,7 @@
  */
 
 import { sha256 } from "@noble/hashes/sha2.js"
-import { base64 } from "@scure/base"
+import { base58, base64 } from "@scure/base"
 import { decodeSignedDelegateAction } from "../core/schema.js"
 import type {
   Action,
@@ -158,6 +158,34 @@ function convertActionToNearConnect(action: Action): NearConnectAction {
       type: "DeployContract",
       params: {
         code: dc.code,
+      },
+    }
+  }
+
+  if ("useGlobalContract" in action) {
+    const { contractIdentifier } = action.useGlobalContract
+    return {
+      type: "UseGlobalContract",
+      params: {
+        contractIdentifier:
+          "AccountId" in contractIdentifier
+            ? { accountId: contractIdentifier.AccountId }
+            : {
+                codeHash: base58.encode(
+                  new Uint8Array(contractIdentifier.CodeHash),
+                ),
+              },
+      },
+    }
+  }
+
+  if ("deployGlobalContract" in action) {
+    const { code, deployMode } = action.deployGlobalContract
+    return {
+      type: "DeployGlobalContract",
+      params: {
+        code,
+        deployMode: "AccountId" in deployMode ? "AccountId" : "CodeHash",
       },
     }
   }

--- a/packages/near-kit/src/wallets/types.ts
+++ b/packages/near-kit/src/wallets/types.ts
@@ -83,6 +83,21 @@ export type NearConnectDeleteAccountAction = {
   }
 }
 
+export type NearConnectUseGlobalContractAction = {
+  type: "UseGlobalContract"
+  params: {
+    contractIdentifier: { accountId: string } | { codeHash: string }
+  }
+}
+
+export type NearConnectDeployGlobalContractAction = {
+  type: "DeployGlobalContract"
+  params: {
+    code: Uint8Array
+    deployMode: "CodeHash" | "AccountId"
+  }
+}
+
 export type NearConnectAction =
   | NearConnectCreateAccountAction
   | NearConnectDeployContractAction
@@ -92,6 +107,8 @@ export type NearConnectAction =
   | NearConnectAddKeyAction
   | NearConnectDeleteKeyAction
   | NearConnectDeleteAccountAction
+  | NearConnectUseGlobalContractAction
+  | NearConnectDeployGlobalContractAction
 
 /**
  * NEAR Connect wallet + connector interfaces (structural).

--- a/packages/near-kit/tests/unit/global-account-state.test.ts
+++ b/packages/near-kit/tests/unit/global-account-state.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { Near } from "../../src/core/near.js"
+
+const emptyCodeHash = "11111111111111111111111111111111"
+const codeHash = "1thX6LZfHDZZKUs92febYZhYRcXddmzfzF2NvTkPNE"
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe("global contract account state", () => {
+  it.each([
+    { name: "empty account", fields: {}, hasContract: false },
+    {
+      name: "null global references",
+      fields: { global_contract_account_id: null, global_contract_hash: null },
+      hasContract: false,
+    },
+    {
+      name: "local contract",
+      fields: { code_hash: codeHash },
+      hasContract: true,
+    },
+    {
+      name: "global contract by publisher",
+      fields: { global_contract_account_id: "publisher.testnet" },
+      hasContract: true,
+    },
+    {
+      name: "global contract by hash",
+      fields: { global_contract_hash: codeHash },
+      hasContract: true,
+    },
+  ])("recognizes $name", async ({ fields, hasContract }) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              result: {
+                amount: "1000000000000000000000000",
+                locked: "0",
+                code_hash: emptyCodeHash,
+                storage_usage: 100,
+                storage_paid_at: 0,
+                block_height: 123,
+                block_hash: codeHash,
+                ...fields,
+              },
+            }),
+          ),
+      ),
+    )
+    const near = new Near({ network: "testnet" })
+    expect(await near.rpc.getAccount("switch.testnet")).toMatchObject(fields)
+    expect((await near.getAccount("switch.testnet")).hasContract).toBe(
+      hasContract,
+    )
+  })
+})

--- a/packages/near-kit/tests/wallets/finality.test.ts
+++ b/packages/near-kit/tests/wallets/finality.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { Near } from "../../src/core/near.js"
+import type { TxExecutionStatus } from "../../src/core/types.js"
+import { InvalidTransactionError } from "../../src/errors/index.js"
+import { fromWalletSelector } from "../../src/wallets/adapters.js"
+import { MockWalletSelector } from "./mock-wallets.js"
+
+async function setup(
+  level: TxExecutionStatus,
+  defaultWaitUntil?: TxExecutionStatus,
+) {
+  const wallet = new MockWalletSelector([{ accountId: "alice.testnet" }])
+  const outcome = await wallet.signAndSendTransaction({
+    receiverId: "bob.testnet",
+    actions: [],
+  })
+  const signing = vi.spyOn(wallet, "signAndSendTransaction").mockResolvedValue({
+    ...outcome,
+    final_execution_status: level,
+  } as typeof outcome)
+  const near = new Near({
+    network: "testnet",
+    wallet: fromWalletSelector(wallet),
+    ...(defaultWaitUntil && { defaultWaitUntil }),
+  })
+  const fetch = vi.fn().mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "test",
+        result: { ...outcome, receipts: [] },
+      }),
+    ),
+  )
+  vi.stubGlobal("fetch", fetch)
+  return { near, signing, fetch, outcome }
+}
+afterEach(() => vi.unstubAllGlobals())
+describe("wallet transaction finality", () => {
+  it("waits for explicit FINAL using the submitted hash", async () => {
+    const { near, signing, fetch } = await setup("EXECUTED_OPTIMISTIC")
+    const result = await near
+      .transaction("alice.testnet")
+      .transfer("bob.testnet", "1 NEAR")
+      .send({ waitUntil: "FINAL" })
+    expect(result.final_execution_status).toBe("FINAL")
+    expect(signing).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(fetch.mock.calls[0]?.[1].body)).toMatchObject({
+      method: "EXPERIMENTAL_tx_status",
+      params: {
+        tx_hash: "mock-tx-hash",
+        sender_account_id: "alice.testnet",
+        wait_until: "FINAL",
+      },
+    })
+  })
+  it("queries the account that actually signed the returned transaction", async () => {
+    const { near, signing, fetch, outcome } = await setup("EXECUTED_OPTIMISTIC")
+    if (!outcome.transaction) throw new Error("Missing fixture transaction")
+    signing.mockResolvedValue({
+      ...outcome,
+      final_execution_status: "EXECUTED_OPTIMISTIC",
+      transaction: { ...outcome.transaction, signer_id: "selected.testnet" },
+    })
+    await near
+      .transaction("alice.testnet")
+      .transfer("bob.testnet", "1 NEAR")
+      .send({ waitUntil: "FINAL" })
+    expect(
+      JSON.parse(fetch.mock.calls[0]?.[1].body).params.sender_account_id,
+    ).toBe("selected.testnet")
+  })
+  it.each([
+    "builder",
+    "call",
+    "send",
+  ])("honors configured FINAL through %s", async (method) => {
+    const { near, fetch } = await setup("EXECUTED_OPTIMISTIC", "FINAL")
+    if (method === "builder")
+      await near
+        .transaction("alice.testnet")
+        .transfer("bob.testnet", "1 NEAR")
+        .send()
+    else if (method === "call") await near.call("bob.testnet", "check_in", {})
+    else await near.send("bob.testnet", "1 NEAR")
+    expect(JSON.parse(fetch.mock.calls[0]?.[1].body).params.wait_until).toBe(
+      "FINAL",
+    )
+  })
+  it("honors explicit FINAL through call", async () => {
+    const { near, fetch } = await setup("EXECUTED_OPTIMISTIC")
+    await near.call("bob.testnet", "check_in", {}, { waitUntil: "FINAL" })
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+  it.each([
+    ["FINAL", "FINAL", false],
+    ["EXECUTED", "EXECUTED_OPTIMISTIC", false],
+    ["EXECUTED_OPTIMISTIC", "INCLUDED", false],
+    ["INCLUDED_FINAL", "EXECUTED_OPTIMISTIC", true],
+    ["EXECUTED_OPTIMISTIC", "INCLUDED_FINAL", true],
+  ] as const)("%s satisfies %s: reconcile=%s", async (level, requested, reconcile) => {
+    const { near, fetch } = await setup(level)
+    await near
+      .transaction("alice.testnet")
+      .transfer("bob.testnet", "1 NEAR")
+      .send({ waitUntil: requested })
+    expect(fetch).toHaveBeenCalledTimes(reconcile ? 1 : 0)
+  })
+  it("raises typed execution errors even when the wallet reports FINAL", async () => {
+    const { near, signing, fetch, outcome } = await setup("FINAL")
+    const failure = {
+      ...outcome,
+      status: {
+        Failure: {
+          ActionError: {
+            index: 0,
+            kind: { AccountAlreadyExists: { account_id: "bob.testnet" } },
+          },
+        },
+      },
+    }
+    signing.mockResolvedValue(failure)
+    fetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: "test",
+          result: { ...failure, receipts: [] },
+        }),
+      ),
+    )
+    await expect(near.send("bob.testnet", "1 NEAR")).rejects.toBeInstanceOf(
+      InvalidTransactionError,
+    )
+    expect(signing).toHaveBeenCalledTimes(1)
+  })
+  it("lets an explicit wait level override configured FINAL", async () => {
+    const { near, fetch } = await setup("EXECUTED_OPTIMISTIC", "FINAL")
+    await near
+      .transaction("alice.testnet")
+      .transfer("bob.testnet", "1 NEAR")
+      .send({ waitUntil: "INCLUDED" })
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it("fails without resubmitting when a wallet omits the hash", async () => {
+    const { near, signing, fetch } = await setup("EXECUTED_OPTIMISTIC")
+    signing.mockResolvedValue({ final_execution_status: "NONE" })
+    await expect(near.send("bob.testnet", "1 NEAR")).rejects.toThrow(
+      "Wallet did not return a transaction hash",
+    )
+    expect(signing).toHaveBeenCalledTimes(1)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it("never signs again when reconciliation fails", async () => {
+    const { near, signing } = await setup("EXECUTED_OPTIMISTIC")
+    vi.spyOn(near.rpc, "getTransactionStatus").mockRejectedValue(
+      new Error("RPC unavailable"),
+    )
+    await expect(
+      near
+        .transaction("alice.testnet")
+        .transfer("bob.testnet", "1 NEAR")
+        .send({ waitUntil: "FINAL" }),
+    ).rejects.toThrow("RPC unavailable")
+    expect(signing).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/near-kit/tests/wallets/global-contracts.test.ts
+++ b/packages/near-kit/tests/wallets/global-contracts.test.ts
@@ -1,0 +1,99 @@
+import type { ConnectorAction } from "@hot-labs/near-connect"
+import { describe, expect, it } from "vitest"
+import { Near } from "../../src/core/near.js"
+import { fromNearConnect } from "../../src/wallets/adapters.js"
+import { MockNearConnect } from "./mock-wallets.js"
+
+const accountId = "switch.testnet"
+const codeHash = "1thX6LZfHDZZKUs92febYZhYRcXddmzfzF2NvTkPNE"
+
+function setup() {
+  const connector = new MockNearConnect([{ accountId }])
+  const near = new Near({
+    network: "testnet",
+    wallet: fromNearConnect(connector),
+  })
+  return { connector, near }
+}
+
+describe("Global contracts through NEAR Connect", () => {
+  it.each([
+    {
+      name: "publisher account",
+      reference: { accountId: "publisher.testnet" },
+      contractIdentifier: { accountId: "publisher.testnet" },
+    },
+    {
+      name: "base58 code hash",
+      reference: { codeHash },
+      contractIdentifier: { codeHash },
+    },
+    {
+      name: "code hash bytes",
+      reference: {
+        codeHash: Uint8Array.from({ length: 32 }, (_, index) => index),
+      },
+      contractIdentifier: { codeHash },
+    },
+  ])("deploys by $name and initializes in the same transaction", async ({
+    reference,
+    contractIdentifier,
+  }) => {
+    const { connector, near } = setup()
+    const args = { challenge_delay_ms: 60_000, friends: [] }
+
+    await near
+      .transaction(accountId)
+      .deployFromPublished(reference)
+      .functionCall(accountId, "init", args, { gas: "100 Tgas" })
+      .send()
+
+    const transactions = connector
+      .getCallLog()
+      .filter((call) => call.method === "signAndSendTransaction")
+    expect(transactions).toHaveLength(1)
+    expect(transactions[0]?.params).toEqual({
+      signerId: accountId,
+      receiverId: accountId,
+      actions: [
+        { type: "UseGlobalContract", params: { contractIdentifier } },
+        {
+          type: "FunctionCall",
+          params: {
+            methodName: "init",
+            args,
+            gas: "100000000000000",
+            deposit: "0",
+          },
+        },
+      ] satisfies ConnectorAction[],
+    })
+  })
+
+  it.each([
+    { identifiedBy: "account" as const, deployMode: "AccountId" as const },
+    { identifiedBy: "hash" as const, deployMode: "CodeHash" as const },
+  ])("publishes code identified by $identifiedBy", async ({
+    identifiedBy,
+    deployMode,
+  }) => {
+    const { connector, near } = setup()
+    const code = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0])
+
+    await near
+      .transaction(accountId)
+      .publishContract(code, { identifiedBy })
+      .send()
+
+    const transaction = connector
+      .getCallLog()
+      .find((call) => call.method === "signAndSendTransaction")
+    expect(transaction?.params).toEqual({
+      signerId: accountId,
+      receiverId: accountId,
+      actions: [
+        { type: "DeployGlobalContract", params: { code, deployMode } },
+      ] satisfies ConnectorAction[],
+    })
+  })
+})


### PR DESCRIPTION
Wallet-backed `deployFromPublished()` and `publishContract()` currently fail before reaching NEAR Connect. Add both global-contract action conversions, preserving code-hash encoding and action order so deployment and initialization can share one approval. Preserve global-contract references in account views and include them in `hasContract`, so applications do not mistake an account using global code for an empty account.

Wallet transactions also ignore `waitUntil`. Reconcile the submitted hash when additional confirmation is needed, and route `near.call()` and `near.send()` through the same path. Confirmation failures never trigger another signature or resubmission.

Validated with 85 focused wallet/account tests, package build, root typecheck, and lint. Includes regression tests, documentation, and a patch changeset. Live Meteor approval has not been exercised.
